### PR TITLE
Add task editing support

### DIFF
--- a/TaskManager/src/navigation/AppNavigator.js
+++ b/TaskManager/src/navigation/AppNavigator.js
@@ -12,7 +12,11 @@ export default function AppNavigator() {
     <NavigationContainer>
       <Stack.Navigator initialRouteName="TaskList">
         <Stack.Screen name="TaskList" component={TaskListScreen} options={{ title: 'Список задач' }} />
-        <Stack.Screen name="TaskForm" component={TaskFormScreen} options={{ title: 'Новая задача' }} />
+        <Stack.Screen
+          name="TaskForm"
+          component={TaskFormScreen}
+          options={({ route }) => ({ title: route.params?.task ? 'Редактирование' : 'Новая задача' })}
+        />
         <Stack.Screen name="TaskDetail" component={TaskDetailScreen} options={{ title: 'Детали задачи' }} />
       </Stack.Navigator>
     </NavigationContainer>

--- a/TaskManager/src/screens/TaskDetailScreen.js
+++ b/TaskManager/src/screens/TaskDetailScreen.js
@@ -1,11 +1,24 @@
 import React, { useState } from 'react';
 import { View } from 'react-native';
 import { Text, Button } from 'react-native-paper';
-import { updateTaskStatus, deleteTask } from '../services/storageService';
+import { useFocusEffect } from '@react-navigation/native';
+import { updateTaskStatus, deleteTask, getTaskById } from '../services/storageService';
 
 export default function TaskDetailScreen({ route, navigation }) {
   const { task } = route.params;
   const [currentTask, setCurrentTask] = useState(task);
+
+  useFocusEffect(
+    React.useCallback(() => {
+      const loadTask = async () => {
+        const freshTask = await getTaskById(task.id);
+        if (freshTask) {
+          setCurrentTask(freshTask);
+        }
+      };
+      loadTask();
+    }, [task.id])
+  );
 
   const handleStatusChange = async () => {
     const statuses = ['В процессе', 'Завершена', 'Отменена'];
@@ -29,6 +42,14 @@ export default function TaskDetailScreen({ route, navigation }) {
 
       <Button mode="contained" onPress={handleStatusChange} style={{ marginVertical: 8 }}>
         Изменить статус
+      </Button>
+
+      <Button
+        mode="contained"
+        onPress={() => navigation.navigate('TaskForm', { task: currentTask })}
+        style={{ marginVertical: 8 }}
+      >
+        Редактировать
       </Button>
 
       <Button mode="contained" onPress={handleDelete} buttonColor="red">

--- a/TaskManager/src/services/storageService.js
+++ b/TaskManager/src/services/storageService.js
@@ -33,6 +33,26 @@ export const updateTaskStatus = async (taskId, newStatus) => {
   return null;
 };
 
+export const updateTask = async (updatedTask) => {
+  try {
+    const tasks = await getTasks();
+    const index = tasks.findIndex((t) => t.id === updatedTask.id);
+    if (index !== -1) {
+      tasks[index] = { ...tasks[index], ...updatedTask };
+      await AsyncStorage.setItem(TASKS_KEY, JSON.stringify(tasks));
+      return tasks[index];
+    }
+  } catch (error) {
+    console.error('Ошибка при обновлении задачи', error);
+  }
+  return null;
+};
+
+export const getTaskById = async (taskId) => {
+  const tasks = await getTasks();
+  return tasks.find((t) => t.id === taskId);
+};
+
 export const deleteTask = async (taskId) => {
   const tasks = await getTasks();
   const filteredTasks = tasks.filter((t) => t.id !== taskId);


### PR DESCRIPTION
## Summary
- add `updateTask` and `getTaskById` helpers
- allow editing tasks in the form screen
- refresh task details on focus and add edit button
- set task form screen title dynamically

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688cb19fa92483239dc5c67b31409db9