### PR TITLE
Fix TaskItem navigation

### DIFF
--- a/TaskManager/src/components/TaskItem.js
+++ b/TaskManager/src/components/TaskItem.js
@@ -2,11 +2,10 @@ import React from 'react';
 import { TouchableOpacity, View, Text, Button } from 'react-native';
 import styles from '../styles/styles';
 
-const TaskItem = ({ task, navigation, onToggle }) => (
-  <TouchableOpacity
-    style={styles.item}
-    onPress={() => navigation.navigate('TaskDetail', { task })}
-  >
+// navigation should be handled by the parent component. This component accepts
+// an onPress callback so that it can be reused in different contexts.
+const TaskItem = ({ task, onPress, onToggle }) => (
+  <TouchableOpacity style={styles.item} onPress={onPress}>
     <View>
       <Text style={styles.title}>{task.title}</Text>
       <Text>{task.date}</Text>

--- a/TaskManager/src/styles/styles.js
+++ b/TaskManager/src/styles/styles.js
@@ -1,6 +1,19 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
+  item: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: 12,
+    marginVertical: 4,
+    backgroundColor: '#fff',
+    borderRadius: 4,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '500',
+  },
   fab: {
   position: 'absolute',
   margin: 16,


### PR DESCRIPTION
## Summary
- fix TaskItem component props so parent handles navigation
- add missing item/title styles for TaskItem

## Testing
- `npm install`
- `npx expo-doctor` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_688cb64ed824832392ca5a9d41ad6a0a