### PR TITLE
Implement Context API and i18n support

### DIFF
--- a/TaskManager/App.js
+++ b/TaskManager/App.js
@@ -3,6 +3,7 @@ import * as Notifications from 'expo-notifications';
 import { Provider as PaperProvider } from 'react-native-paper';
 import AppNavigator from './src/navigation/AppNavigator';
 import { registerForPushNotificationsAsync } from './src/services/notificationService';
+import { TaskProvider } from './src/context/TaskContext';
 import SignInScreen from './src/screens/SignInScreen';
 
 export default function App() {
@@ -23,11 +24,9 @@ export default function App() {
 
   return (
     <PaperProvider>
-      {user ? (
-        <AppNavigator />
-      ) : (
-        <SignInScreen onSignIn={setUser} />
-      )}
+      <TaskProvider>
+        {user ? <AppNavigator /> : <SignInScreen onSignIn={setUser} />}
+      </TaskProvider>
     </PaperProvider>
   );
 }

--- a/TaskManager/__tests__/notificationService.test.js
+++ b/TaskManager/__tests__/notificationService.test.js
@@ -1,0 +1,23 @@
+jest.mock('expo-notifications', () => ({
+  scheduleNotificationAsync: jest.fn().mockResolvedValue('id'),
+  cancelScheduledNotificationAsync: jest.fn(),
+}));
+jest.mock('expo-device', () => ({}));
+jest.mock('react-native', () => ({ Platform: { OS: 'ios' } }));
+
+const Notifications = require('expo-notifications');
+const { scheduleTaskNotification, cancelTaskNotification } = require('../src/services/notificationService');
+
+describe('notificationService', () => {
+  test('scheduleTaskNotification schedules notification', async () => {
+    const task = { title: 't', date: new Date(Date.now() + 11 * 60000).toISOString(), reminder: '10' };
+    const id = await scheduleTaskNotification(task);
+    expect(id).toBe('id');
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled();
+  });
+
+  test('cancelTaskNotification cancels by id', async () => {
+    await cancelTaskNotification('id');
+    expect(Notifications.cancelScheduledNotificationAsync).toHaveBeenCalledWith('id');
+  });
+});

--- a/TaskManager/__tests__/storageService.test.js
+++ b/TaskManager/__tests__/storageService.test.js
@@ -1,0 +1,42 @@
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+jest.mock('../src/services/supabaseService', () => ({
+  syncTasks: jest.fn(),
+}));
+
+jest.mock('../src/services/notificationService', () => ({
+  cancelTaskNotification: jest.fn(),
+}));
+
+const AsyncStorage = require('@react-native-async-storage/async-storage');
+const { getTasks, saveTask, deleteTask } = require('../src/services/storageService');
+
+describe('storageService', () => {
+  beforeEach(() => {
+    AsyncStorage.getItem.mockReset();
+    AsyncStorage.setItem.mockReset();
+  });
+
+  test('getTasks returns parsed tasks', async () => {
+    const tasks = [{ id: '1', title: 't' }];
+    AsyncStorage.getItem.mockResolvedValue(JSON.stringify(tasks));
+    const res = await getTasks();
+    expect(res[0].id).toBe('1');
+  });
+
+  test('saveTask stores new task', async () => {
+    AsyncStorage.getItem.mockResolvedValue('[]');
+    await saveTask({ id: '1' });
+    expect(AsyncStorage.setItem).toHaveBeenCalled();
+  });
+
+  test('deleteTask removes task', async () => {
+    AsyncStorage.getItem.mockResolvedValue(JSON.stringify([{ id: '1' }]));
+    await deleteTask('1');
+    expect(AsyncStorage.setItem).toHaveBeenCalled();
+  });
+});

--- a/TaskManager/jest.config.js
+++ b/TaskManager/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  transform: {
+    '^.+\\.jsx?$': 'babel-jest'
+  },
+  testEnvironment: 'node'
+};

--- a/TaskManager/package.json
+++ b/TaskManager/package.json
@@ -6,11 +6,13 @@
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "test": "jest"
   },
   "dependencies": {
     "@expo/metro-runtime": "~5.0.4",
     "@react-native-async-storage/async-storage": "2.1.2",
+    "@react-native-community/datetimepicker": "^7.3.3",
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/stack": "^6.3.16",
     "@supabase/supabase-js": "^2.53.0",
@@ -19,7 +21,6 @@
     "expo-auth-session": "^6.2.1",
     "expo-device": "~7.1.4",
     "expo-notifications": "~0.31.4",
-    "@react-native-community/datetimepicker": "^7.3.3",
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
     "react-dom": "19.0.0",
@@ -31,10 +32,14 @@
     "react-native-screens": "~4.11.1",
     "react-native-vector-icons": "^10.0.3",
     "react-native-web": "^0.20.0",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "i18n-js": "^4.5.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.24.0"
+    "@babel/core": "^7.24.0",
+    "@babel/preset-env": "^7.28.0",
+    "babel-jest": "^30.0.5",
+    "jest": "^30.0.5"
   },
   "private": true
 }

--- a/TaskManager/src/constants.js
+++ b/TaskManager/src/constants.js
@@ -1,0 +1,1 @@
+export const TASK_STATUSES = ['В процессе', 'Завершена', 'Отменена'];

--- a/TaskManager/src/context/TaskContext.js
+++ b/TaskManager/src/context/TaskContext.js
@@ -1,0 +1,68 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import {
+  getTasks,
+  saveTask as saveTaskService,
+  updateTask as updateTaskService,
+  updateTaskStatus as updateTaskStatusService,
+  deleteTask as deleteTaskService,
+  toggleTaskPinned as toggleTaskPinnedService,
+} from '../services/storageService';
+
+const TaskContext = createContext({
+  tasks: [],
+  loadTasks: () => {},
+  addTask: () => {},
+  updateTask: () => {},
+  updateStatus: () => {},
+  deleteTask: () => {},
+  togglePin: () => {},
+});
+
+export const TaskProvider = ({ children }) => {
+  const [tasks, setTasks] = useState([]);
+
+  const loadTasks = async () => {
+    const data = await getTasks();
+    setTasks(data);
+  };
+
+  useEffect(() => {
+    loadTasks();
+  }, []);
+
+  const addTask = async (task) => {
+    await saveTaskService(task);
+    await loadTasks();
+  };
+
+  const updateTask = async (task) => {
+    await updateTaskService(task);
+    await loadTasks();
+  };
+
+  const updateStatus = async (id, status) => {
+    await updateTaskStatusService(id, status);
+    await loadTasks();
+  };
+
+  const deleteTask = async (id) => {
+    await deleteTaskService(id);
+    await loadTasks();
+  };
+
+  const togglePin = async (id) => {
+    const res = await toggleTaskPinnedService(id);
+    await loadTasks();
+    return res;
+  };
+
+  return (
+    <TaskContext.Provider
+      value={{ tasks, loadTasks, addTask, updateTask, updateStatus, deleteTask, togglePin }}
+    >
+      {children}
+    </TaskContext.Provider>
+  );
+};
+
+export const useTasks = () => useContext(TaskContext);

--- a/TaskManager/src/i18n/index.js
+++ b/TaskManager/src/i18n/index.js
@@ -1,0 +1,28 @@
+import * as Localization from 'expo-localization';
+import i18n from 'i18n-js';
+
+i18n.fallbacks = true;
+i18n.translations = {
+  en: {
+    taskList: 'Task List',
+    noTasks: 'No tasks',
+    createTask: 'Create task',
+    search: 'Search',
+    edit: 'Edit',
+    newTask: 'New Task',
+    taskDetails: 'Task Details',
+  },
+  ru: {
+    taskList: 'Список задач',
+    noTasks: 'Нет задач',
+    createTask: 'Создать задачу',
+    search: 'Поиск',
+    edit: 'Редактирование',
+    newTask: 'Новая задача',
+    taskDetails: 'Детали задачи',
+  },
+};
+
+i18n.locale = Localization.locale;
+
+export default i18n;

--- a/TaskManager/src/navigation/AppNavigator.js
+++ b/TaskManager/src/navigation/AppNavigator.js
@@ -4,6 +4,7 @@ import { createStackNavigator } from '@react-navigation/stack';
 import TaskListScreen from '../screens/TaskListScreen';
 import TaskFormScreen from '../screens/TaskFormScreen';
 import TaskDetailScreen from '../screens/TaskDetailScreen';
+import i18n from '../i18n';
 
 const Stack = createStackNavigator();
 
@@ -11,15 +12,15 @@ export default function AppNavigator() {
   return (
     <NavigationContainer>
       <Stack.Navigator initialRouteName="TaskList">
-        <Stack.Screen name="TaskList" component={TaskListScreen} options={{ title: 'Список задач' }} />
+        <Stack.Screen name="TaskList" component={TaskListScreen} options={{ title: i18n.t('taskList') }} />
         <Stack.Screen
           name="TaskForm"
           component={TaskFormScreen}
           options={({ route }) => ({
-            title: route.params?.task ? 'Редактирование' : 'Новая задача',
+            title: route.params?.task ? i18n.t('edit') : i18n.t('newTask'),
           })}
         />
-        <Stack.Screen name="TaskDetail" component={TaskDetailScreen} options={{ title: 'Детали задачи' }} />
+        <Stack.Screen name="TaskDetail" component={TaskDetailScreen} options={{ title: i18n.t('taskDetails') }} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/TaskManager/src/screens/TaskDetailScreen.js
+++ b/TaskManager/src/screens/TaskDetailScreen.js
@@ -1,17 +1,18 @@
 import React, { useState } from 'react';
 import { View } from 'react-native';
 import { Text, Button } from 'react-native-paper';
-import { updateTaskStatus, deleteTask } from '../services/storageService';
+import { useTasks } from '../context/TaskContext';
+import { TASK_STATUSES } from '../constants';
 
 export default function TaskDetailScreen({ route, navigation }) {
+  const { updateStatus, deleteTask } = useTasks();
   const { task } = route.params;
   const [currentTask, setCurrentTask] = useState(task);
 
   const handleStatusChange = async () => {
-    const statuses = ['В процессе', 'Завершена', 'Отменена'];
-    const nextStatus = statuses[(statuses.indexOf(currentTask.status) + 1) % statuses.length];
-    const updatedTask = await updateTaskStatus(currentTask.id, nextStatus);
-    setCurrentTask(updatedTask);
+    const nextStatus = TASK_STATUSES[(TASK_STATUSES.indexOf(currentTask.status) + 1) % TASK_STATUSES.length];
+    await updateStatus(currentTask.id, nextStatus);
+    setCurrentTask((prev) => ({ ...prev, status: nextStatus }));
   };
 
   const handleDelete = async () => {

--- a/TaskManager/src/screens/TaskFormScreen.js
+++ b/TaskManager/src/screens/TaskFormScreen.js
@@ -2,10 +2,12 @@ import React, { useState, useEffect } from 'react';
 import { View, Platform } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { TextInput, Button, Snackbar, Dialog, Portal, RadioButton, Switch, Text } from 'react-native-paper';
-import { saveTask, updateTask } from '../services/storageService';
+import { useTasks } from '../context/TaskContext';
 import { scheduleTaskNotification, cancelTaskNotification } from '../services/notificationService';
+import { TASK_STATUSES } from '../constants';
 
 export default function TaskFormScreen({ navigation, route }) {
+  const { addTask, updateTask } = useTasks();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [date, setDate] = useState('');
@@ -66,7 +68,7 @@ export default function TaskFormScreen({ navigation, route }) {
       description,
       date: taskDateTime.toISOString(),
       address,
-      status: editingTask ? editingTask.status : 'В процессе',
+      status: editingTask ? editingTask.status : TASK_STATUSES[0],
       reminder: reminderTime,
       repeat,
       customDays: repeat === 'custom' ? parseInt(customDays, 10) : undefined,
@@ -87,7 +89,7 @@ export default function TaskFormScreen({ navigation, route }) {
     if (editingTask) {
       await updateTask(newTask);
     } else {
-      await saveTask(newTask);
+      await addTask(newTask);
     }
 
     setDialogVisible(false);

--- a/TaskManager/src/services/notificationService.js
+++ b/TaskManager/src/services/notificationService.js
@@ -3,21 +3,25 @@ import * as Device from 'expo-device';
 import { Platform } from 'react-native';
 
 export async function registerForPushNotificationsAsync() {
-  if (Device.isDevice) {
-    const { status: existingStatus } = await Notifications.getPermissionsAsync();
-    let finalStatus = existingStatus;
+  try {
+    if (Device.isDevice) {
+      const { status: existingStatus } = await Notifications.getPermissionsAsync();
+      let finalStatus = existingStatus;
 
-    if (existingStatus !== 'granted') {
-      const { status } = await Notifications.requestPermissionsAsync();
-      finalStatus = status;
-    }
+      if (existingStatus !== 'granted') {
+        const { status } = await Notifications.requestPermissionsAsync();
+        finalStatus = status;
+      }
 
-    if (finalStatus !== 'granted') {
-      alert('Не удалось получить разрешение на отправку уведомлений.');
-      return;
+      if (finalStatus !== 'granted') {
+        alert('Не удалось получить разрешение на отправку уведомлений.');
+        return;
+      }
+    } else {
+      alert('Push-уведомления доступны только на реальных устройствах.');
     }
-  } else {
-    alert('Push-уведомления доступны только на реальных устройствах.');
+  } catch (e) {
+    console.error('Ошибка регистрации уведомлений', e);
   }
 }
 

--- a/TaskManager/src/services/storageService.js
+++ b/TaskManager/src/services/storageService.js
@@ -34,46 +34,64 @@ export const saveTask = async (task) => {
 };
 
 export const updateTaskStatus = async (taskId, newStatus) => {
-  const tasks = await getTasks();
-  const index = tasks.findIndex((t) => t.id === taskId);
-  if (index !== -1) {
-    tasks[index].status = newStatus;
-    await AsyncStorage.setItem(TASKS_KEY, JSON.stringify(tasks));
-    await syncTasks(tasks);
-    return tasks[index];
+  try {
+    const tasks = await getTasks();
+    const index = tasks.findIndex((t) => t.id === taskId);
+    if (index !== -1) {
+      tasks[index].status = newStatus;
+      await AsyncStorage.setItem(TASKS_KEY, JSON.stringify(tasks));
+      await syncTasks(tasks);
+      return tasks[index];
+    }
+    return null;
+  } catch (error) {
+    console.error('Ошибка при обновлении статуса задачи', error);
+    return null;
   }
-  return null;
 };
 
 export const updateTask = async (task) => {
-  const tasks = await getTasks();
-  const index = tasks.findIndex((t) => t.id === task.id);
-  if (index !== -1) {
-    tasks[index] = task;
-    await AsyncStorage.setItem(TASKS_KEY, JSON.stringify(tasks));
-    await syncTasks(tasks);
+  try {
+    const tasks = await getTasks();
+    const index = tasks.findIndex((t) => t.id === task.id);
+    if (index !== -1) {
+      tasks[index] = task;
+      await AsyncStorage.setItem(TASKS_KEY, JSON.stringify(tasks));
+      await syncTasks(tasks);
+    }
+  } catch (error) {
+    console.error('Ошибка при обновлении задачи', error);
   }
 };
 
 export const toggleTaskPinned = async (taskId) => {
-  const tasks = await getTasks();
-  const index = tasks.findIndex((t) => t.id === taskId);
-  if (index !== -1) {
-    tasks[index].pinned = !tasks[index].pinned;
-    await AsyncStorage.setItem(TASKS_KEY, JSON.stringify(tasks));
-    await syncTasks(tasks);
-    return tasks[index];
+  try {
+    const tasks = await getTasks();
+    const index = tasks.findIndex((t) => t.id === taskId);
+    if (index !== -1) {
+      tasks[index].pinned = !tasks[index].pinned;
+      await AsyncStorage.setItem(TASKS_KEY, JSON.stringify(tasks));
+      await syncTasks(tasks);
+      return tasks[index];
+    }
+    return null;
+  } catch (error) {
+    console.error('Ошибка при изменении закрепления задачи', error);
+    return null;
   }
-  return null;
 };
 
 export const deleteTask = async (taskId) => {
-  const tasks = await getTasks();
-  const filteredTasks = tasks.filter((t) => t.id !== taskId);
-  const deletedTask = tasks.find((t) => t.id === taskId);
-  if (deletedTask?.notificationId) {
-    await cancelTaskNotification(deletedTask.notificationId);
+  try {
+    const tasks = await getTasks();
+    const filteredTasks = tasks.filter((t) => t.id !== taskId);
+    const deletedTask = tasks.find((t) => t.id === taskId);
+    if (deletedTask?.notificationId) {
+      await cancelTaskNotification(deletedTask.notificationId);
+    }
+    await AsyncStorage.setItem(TASKS_KEY, JSON.stringify(filteredTasks));
+    await syncTasks(filteredTasks);
+  } catch (error) {
+    console.error('Ошибка при удалении задачи', error);
   }
-  await AsyncStorage.setItem(TASKS_KEY, JSON.stringify(filteredTasks));
-  await syncTasks(filteredTasks);
 };


### PR DESCRIPTION
## Summary
- centralize tasks with React context
- move task statuses to `constants.js`
- add basic i18n setup
- add error handling in services
- write Jest tests for services

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688ccd78b65083239b3c12024722c862