### PR TITLE
Improve theme and icons

### DIFF
--- a/TaskManager/src/context/ThemeContext.js
+++ b/TaskManager/src/context/ThemeContext.js
@@ -3,11 +3,37 @@ import { useColorScheme } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { MD3DarkTheme, MD3LightTheme } from 'react-native-paper';
 
+const customLightTheme = {
+  ...MD3LightTheme,
+  colors: {
+    ...MD3LightTheme.colors,
+    primary: '#6750A4',
+    secondary: '#9A82DB',
+    background: '#F4F4F7',
+    surface: '#FFFFFF',
+    onBackground: '#1C1B1F',
+    onSurface: '#1C1B1F',
+  },
+};
+
+const customDarkTheme = {
+  ...MD3DarkTheme,
+  colors: {
+    ...MD3DarkTheme.colors,
+    primary: '#D0BCFF',
+    secondary: '#CCC2DC',
+    background: '#1C1B1F',
+    surface: '#2B2A2E',
+    onBackground: '#E6E1E5',
+    onSurface: '#E6E1E5',
+  },
+};
+
 const STORAGE_KEY = 'APP_THEME';
 
 const ThemeContext = createContext({
   theme: 'light',
-  paperTheme: MD3LightTheme,
+  paperTheme: customLightTheme,
   toggleTheme: () => {},
 });
 
@@ -29,7 +55,7 @@ export const ThemeProvider = ({ children }) => {
     await AsyncStorage.setItem(STORAGE_KEY, newTheme);
   };
 
-  const paperTheme = theme === 'light' ? MD3LightTheme : MD3DarkTheme;
+  const paperTheme = theme === 'light' ? customLightTheme : customDarkTheme;
 
   return (
     <ThemeContext.Provider value={{ theme, paperTheme, toggleTheme }}>

--- a/TaskManager/src/screens/SignInScreen.js
+++ b/TaskManager/src/screens/SignInScreen.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import { View } from 'react-native';
 import { Button } from 'react-native-paper';
+import { useThemePreferences } from '../context/ThemeContext';
 import { signInWithGoogle } from '../services/authService';
 
 export default function SignInScreen({ onSignIn }) {
+  const { paperTheme } = useThemePreferences();
   const handleSignIn = async () => {
     const user = await signInWithGoogle();
     if (user) {
@@ -12,7 +14,7 @@ export default function SignInScreen({ onSignIn }) {
   };
 
   return (
-    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: paperTheme.colors.background }}>
       <Button mode="contained" onPress={handleSignIn}>
         Войти через Google
       </Button>

--- a/TaskManager/src/screens/TaskDetailScreen.js
+++ b/TaskManager/src/screens/TaskDetailScreen.js
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
 import { View } from 'react-native';
 import { Text, Button } from 'react-native-paper';
+import { useThemePreferences } from '../context/ThemeContext';
 import { useTasks } from '../context/TaskContext';
 import { TASK_STATUSES } from '../constants';
 
 export default function TaskDetailScreen({ route, navigation }) {
   const { updateStatus, deleteTask } = useTasks();
+  const { paperTheme } = useThemePreferences();
   const { task } = route.params;
   const [currentTask, setCurrentTask] = useState(task);
 
@@ -21,7 +23,7 @@ export default function TaskDetailScreen({ route, navigation }) {
   };
 
   return (
-    <View style={{ flex: 1, padding: 16 }}>
+    <View style={{ flex: 1, padding: 16, backgroundColor: paperTheme.colors.background }}>
       <Text variant="titleLarge">{currentTask.title}</Text>
       <Text>{currentTask.description}</Text>
       <Text>Дата: {currentTask.date}</Text>

--- a/TaskManager/src/screens/TaskFormScreen.js
+++ b/TaskManager/src/screens/TaskFormScreen.js
@@ -2,12 +2,14 @@ import React, { useState, useEffect } from 'react';
 import { View, Platform } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { TextInput, Button, Snackbar, Dialog, Portal, RadioButton, Switch, Text } from 'react-native-paper';
+import { useThemePreferences } from '../context/ThemeContext';
 import { useTasks } from '../context/TaskContext';
 import { scheduleTaskNotification, cancelTaskNotification } from '../services/notificationService';
 import { TASK_STATUSES } from '../constants';
 
 export default function TaskFormScreen({ navigation, route }) {
   const { addTask, updateTask } = useTasks();
+  const { paperTheme } = useThemePreferences();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [date, setDate] = useState('');
@@ -114,7 +116,7 @@ export default function TaskFormScreen({ navigation, route }) {
   };
 
   return (
-    <View style={{ flex: 1, padding: 16 }}>
+    <View style={{ flex: 1, padding: 16, backgroundColor: paperTheme.colors.background }}>
       <TextInput label="Заголовок" value={title} onChangeText={setTitle} style={{ marginBottom: 8 }} />
       <TextInput label="Описание" value={description} onChangeText={setDescription} style={{ marginBottom: 8 }} />
       <TextInput

--- a/TaskManager/src/screens/TaskListScreen.js
+++ b/TaskManager/src/screens/TaskListScreen.js
@@ -12,7 +12,7 @@ import styles from '../styles/styles';
 
 export default function TaskListScreen({ navigation }) {
   const { tasks: storedTasks, togglePin } = useTasks();
-  const { theme, toggleTheme } = useThemePreferences();
+  const { theme, toggleTheme, paperTheme } = useThemePreferences();
   const [tasks, setTasks] = useState([]);
   const [menuVisible, setMenuVisible] = useState(false);
   const [filterMenuVisible, setFilterMenuVisible] = useState(false);
@@ -70,7 +70,7 @@ export default function TaskListScreen({ navigation }) {
   };
 
   return (
-    <View style={{ flex: 1 }}>
+    <View style={{ flex: 1, backgroundColor: paperTheme.colors.background }}>
       {/* Appbar с меню сортировки */}
       <Appbar.Header>
         <Appbar.Content title={i18n.t('taskList')} />
@@ -80,7 +80,6 @@ export default function TaskListScreen({ navigation }) {
           anchor={
             <Appbar.Action
               icon="sort"
-              color="white"
               onPress={() => setMenuVisible(true)}
             />
           }
@@ -94,7 +93,6 @@ export default function TaskListScreen({ navigation }) {
           anchor={
             <Appbar.Action
               icon="filter"
-              color="white"
               onPress={() => setFilterMenuVisible(true)}
             />
           }
@@ -106,7 +104,6 @@ export default function TaskListScreen({ navigation }) {
         </Menu>
         <Appbar.Action
           icon={theme === 'light' ? 'weather-night' : 'white-balance-sunny'}
-          color="white"
           onPress={toggleTheme}
         />
       </Appbar.Header>
@@ -145,7 +142,7 @@ export default function TaskListScreen({ navigation }) {
 
       {/* Кнопка добавления задачи */}
       <FAB
-        style={styles.fab}
+        style={[styles.fab, { backgroundColor: paperTheme.colors.primary }]}
         icon="plus"
         onPress={() => navigation.navigate('TaskForm')}
       />


### PR DESCRIPTION
## Summary
- customize light/dark theme colors
- adapt screens to use theme background and primary color
- remove hardcoded icon colors
- ensure UI elements look good in both modes

## Testing
- `npm test --silent` *(fails: Cannot find module './ScriptTransformer')*

------
https://chatgpt.com/codex/tasks/task_e_688d0fb92b948323b9b44bba011f51b9