### PR TITLE
Add custom fonts and input preview

### DIFF
--- a/TaskManager/App.js
+++ b/TaskManager/App.js
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import * as Notifications from 'expo-notifications';
 import { Provider as PaperProvider } from 'react-native-paper';
+import { useFonts, Inter_400Regular, Inter_500Medium } from '@expo-google-fonts/inter';
+import { RobotoFlex_400Regular, RobotoFlex_500Medium } from '@expo-google-fonts/roboto-flex';
 import AppNavigator from './src/navigation/AppNavigator';
 import { registerForPushNotificationsAsync } from './src/services/notificationService';
 import { TaskProvider } from './src/context/TaskContext';
@@ -10,6 +12,16 @@ import SignInScreen from './src/screens/SignInScreen';
 function MainApp() {
   const [user, setUser] = useState(null);
   const { paperTheme } = useThemePreferences();
+  const [fontsLoaded] = useFonts({
+    Inter_400Regular,
+    Inter_500Medium,
+    RobotoFlex_400Regular,
+    RobotoFlex_500Medium,
+  });
+
+  if (!fontsLoaded) {
+    return null;
+  }
 
   useEffect(() => {
     // Запрос разрешений на уведомления

--- a/TaskManager/package-lock.json
+++ b/TaskManager/package-lock.json
@@ -8,6 +8,8 @@
       "name": "task-manager",
       "version": "1.0.0",
       "dependencies": {
+        "@expo-google-fonts/inter": "^0.4.1",
+        "@expo-google-fonts/roboto-flex": "^0.4.0",
         "@expo/metro-runtime": "~5.0.4",
         "@react-native-async-storage/async-storage": "2.1.2",
         "@react-native-community/datetimepicker": "8.4.1",
@@ -19,6 +21,7 @@
         "expo": "^53.0.20",
         "expo-auth-session": "^6.2.1",
         "expo-device": "~7.1.4",
+        "expo-font": "^13.3.2",
         "expo-localization": "~16.1.6",
         "expo-notifications": "~0.31.4",
         "expo-status-bar": "~2.2.3",
@@ -27,6 +30,7 @@
         "react-dom": "19.0.0",
         "react-native": "0.79.5",
         "react-native-gesture-handler": "~2.24.0",
+        "react-native-markdown-display": "^7.0.2",
         "react-native-paper": "^5.12.3",
         "react-native-reanimated": "~3.17.4",
         "react-native-safe-area-context": "5.4.0",
@@ -2165,6 +2169,18 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/@expo-google-fonts/inter": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/inter/-/inter-0.4.1.tgz",
+      "integrity": "sha512-ypL+XokTHEG+ie/nxNj/mS38afMrY4Li4oKvTJf9k9XvH7I21qfTGCsDtlZ6nIUWEAy1odoUZISdXT1nfMh4kA==",
+      "license": "MIT AND OFL-1.1"
+    },
+    "node_modules/@expo-google-fonts/roboto-flex": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/roboto-flex/-/roboto-flex-0.4.0.tgz",
+      "integrity": "sha512-G5hfT9gMfVV1GpcScKBBLIMPZCtWnML8xTG5lPebdMrjFFeeEEekqMSh2vRSekBsA8nHWzXdzzkIidkDByYMoA==",
+      "license": "MIT AND OFL-1.1"
     },
     "node_modules/@expo/cli": {
       "version": "0.24.20",
@@ -4584,6 +4600,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001731",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
@@ -5040,6 +5065,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/css-in-js-utils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz",
@@ -5047,6 +5081,17 @@
       "license": "MIT",
       "dependencies": {
         "hyphenate-style-name": "^1.0.3"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/csstype": {
@@ -5312,6 +5357,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/entities": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/env-editor": {
       "version": "0.4.2",
@@ -7875,6 +7926,15 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -8056,6 +8116,31 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "entities": "~2.0.0",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/marky": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
@@ -8070,6 +8155,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "license": "MIT"
     },
     "node_modules/memoize-one": {
       "version": "5.2.1",
@@ -9555,6 +9646,15 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-fit-image": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/react-native-fit-image/-/react-native-fit-image-1.5.5.tgz",
+      "integrity": "sha512-Wl3Vq2DQzxgsWKuW4USfck9zS7YzhvLNPpkwUUCF90bL32e1a0zOVQ3WsJILJOwzmPdHfzZmWasiiAUNBkhNkg==",
+      "license": "Beerware",
+      "dependencies": {
+        "prop-types": "^15.5.10"
+      }
+    },
     "node_modules/react-native-gesture-handler": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.24.0.tgz",
@@ -9578,6 +9678,22 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-markdown-display": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-native-markdown-display/-/react-native-markdown-display-7.0.2.tgz",
+      "integrity": "sha512-Mn4wotMvMfLAwbX/huMLt202W5DsdpMO/kblk+6eUs55S57VVNni1gzZCh5qpznYLjIQELNh50VIozEfY6fvaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-to-react-native": "^3.0.0",
+        "markdown-it": "^10.0.0",
+        "prop-types": "^15.7.2",
+        "react-native-fit-image": "^1.5.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.2.0",
+        "react-native": ">=0.50.4"
       }
     },
     "node_modules/react-native-paper": {
@@ -11139,6 +11255,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "6.21.3",

--- a/TaskManager/package.json
+++ b/TaskManager/package.json
@@ -10,6 +10,8 @@
     "test": "jest"
   },
   "dependencies": {
+    "@expo-google-fonts/inter": "^0.4.1",
+    "@expo-google-fonts/roboto-flex": "^0.4.0",
     "@expo/metro-runtime": "~5.0.4",
     "@react-native-async-storage/async-storage": "2.1.2",
     "@react-native-community/datetimepicker": "8.4.1",
@@ -17,9 +19,11 @@
     "@react-navigation/stack": "^6.3.16",
     "@supabase/supabase-js": "^2.53.0",
     "@types/react": "~19.0.10",
+    "dayjs": "^1.11.10",
     "expo": "^53.0.20",
     "expo-auth-session": "^6.2.1",
     "expo-device": "~7.1.4",
+    "expo-font": "^13.3.2",
     "expo-localization": "~16.1.6",
     "expo-notifications": "~0.31.4",
     "expo-status-bar": "~2.2.3",
@@ -28,14 +32,14 @@
     "react-dom": "19.0.0",
     "react-native": "0.79.5",
     "react-native-gesture-handler": "~2.24.0",
+    "react-native-markdown-display": "^7.0.2",
     "react-native-paper": "^5.12.3",
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-vector-icons": "^10.0.3",
     "react-native-web": "^0.20.0",
-    "typescript": "~5.8.3",
-    "dayjs": "^1.11.10"
+    "typescript": "~5.8.3"
   },
   "devDependencies": {
     "@babel/core": "^7.24.0",

--- a/TaskManager/src/context/ThemeContext.js
+++ b/TaskManager/src/context/ThemeContext.js
@@ -3,9 +3,16 @@ import { useColorScheme } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { MD3DarkTheme, MD3LightTheme } from 'react-native-paper';
 
+const baseFonts = {
+  bodyLarge: { ...MD3LightTheme.fonts.bodyLarge, fontFamily: 'Inter_400Regular' },
+  bodyMedium: { ...MD3LightTheme.fonts.bodyMedium, fontFamily: 'Inter_400Regular' },
+  titleLarge: { ...MD3LightTheme.fonts.titleLarge, fontFamily: 'RobotoFlex_500Medium' },
+};
+
 const createThemes = (accent) => ({
   light: {
     ...MD3LightTheme,
+    fonts: { ...MD3LightTheme.fonts, ...baseFonts },
     colors: {
       ...MD3LightTheme.colors,
       primary: accent,
@@ -18,6 +25,7 @@ const createThemes = (accent) => ({
   },
   dark: {
     ...MD3DarkTheme,
+    fonts: { ...MD3DarkTheme.fonts, ...baseFonts },
     colors: {
       ...MD3DarkTheme.colors,
       primary: accent,

--- a/TaskManager/src/screens/TaskFormScreen.js
+++ b/TaskManager/src/screens/TaskFormScreen.js
@@ -1,7 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { View, Platform } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
+import Markdown from 'react-native-markdown-display';
 import { TextInput, Button, Snackbar, Dialog, Portal, RadioButton, Switch, Text } from 'react-native-paper';
+import styles from '../styles/styles';
 import { useThemePreferences } from '../context/ThemeContext';
 import { useTasks } from '../context/TaskContext';
 import { scheduleTaskNotification, cancelTaskNotification } from '../services/notificationService';
@@ -117,14 +119,31 @@ export default function TaskFormScreen({ navigation, route }) {
 
   return (
     <View style={{ flex: 1, padding: 16, backgroundColor: paperTheme.colors.background }}>
-      <TextInput label="Заголовок" value={title} onChangeText={setTitle} style={{ marginBottom: 8 }} />
-      <TextInput label="Описание" value={description} onChangeText={setDescription} style={{ marginBottom: 8 }} />
       <TextInput
+        mode="outlined"
+        autoFocus
+        autoComplete="off"
+        label="Заголовок"
+        value={title}
+        onChangeText={setTitle}
+        style={styles.input}
+      />
+      <TextInput
+        mode="outlined"
+        label="Описание"
+        value={description}
+        onChangeText={setDescription}
+        multiline
+        style={styles.input}
+      />
+      {description ? <Markdown style={{ marginBottom: 8 }}>{description}</Markdown> : null}
+      <TextInput
+        mode="outlined"
         label="Дата"
         value={date}
         showSoftInputOnFocus={false}
         onPressIn={() => setShowDatePicker(true)}
-        style={{ marginBottom: 8 }}
+        style={styles.input}
       />
       {showDatePicker && (
         <DateTimePicker
@@ -136,11 +155,12 @@ export default function TaskFormScreen({ navigation, route }) {
       )}
 
       <TextInput
+        mode="outlined"
         label="Время"
         value={time}
         showSoftInputOnFocus={false}
         onPressIn={() => setShowTimePicker(true)}
-        style={{ marginBottom: 8 }}
+        style={styles.input}
       />
       {showTimePicker && (
         <DateTimePicker
@@ -150,7 +170,13 @@ export default function TaskFormScreen({ navigation, route }) {
           onChange={onTimeChange}
         />
       )}
-      <TextInput label="Адрес" value={address} onChangeText={setAddress} style={{ marginBottom: 8 }} />
+      <TextInput
+        mode="outlined"
+        label="Адрес"
+        value={address}
+        onChangeText={setAddress}
+        style={styles.input}
+      />
       <RadioButton.Group onValueChange={setCategory} value={category}>
         <RadioButton.Item label="Работа" value="Работа" />
         <RadioButton.Item label="Учёба" value="Учёба" />

--- a/TaskManager/src/styles/styles.js
+++ b/TaskManager/src/styles/styles.js
@@ -9,12 +9,14 @@ export default StyleSheet.create({
     elevation: 0,
   },
   title: {
-    fontSize: 16,
+    fontSize: 18,
     fontWeight: '500',
+    fontFamily: 'Inter_500Medium',
   },
   secondary: {
-    fontSize: 12,
+    fontSize: 14,
     color: '#777',
+    fontFamily: 'Inter_400Regular',
   },
   fab: {
   position: 'absolute',
@@ -38,6 +40,7 @@ export default StyleSheet.create({
   },
   input: {
     marginBottom: 12,
+    borderRadius: 8,
   },
   addButton: {
     marginTop: 16,
@@ -49,8 +52,9 @@ export default StyleSheet.create({
     marginTop: 16,
   },
   detailTitle: {
-    fontSize: 18,
-    fontWeight: 'bold',
+    fontSize: 20,
+    fontWeight: '500',
+    fontFamily: 'RobotoFlex_500Medium',
     marginBottom: 12,
   },
 });


### PR DESCRIPTION
## Summary
- add Inter and Roboto Flex fonts via expo
- load fonts in `App.js`
- apply fonts in theme and styles
- style form inputs with outlines and add markdown preview

## Testing
- `npm test` *(fails: Cannot find module './ScriptTransformer')*

------
https://chatgpt.com/codex/tasks/task_e_688d26ffb9688323960f17ff0ec57ca9