### PR TITLE
Improve task context updates

### DIFF
--- a/TaskManager/src/services/storageService.js
+++ b/TaskManager/src/services/storageService.js
@@ -95,3 +95,12 @@ export const deleteTask = async (taskId) => {
     console.error('Ошибка при удалении задачи', error);
   }
 };
+
+export const saveTasksList = async (tasks) => {
+  try {
+    await AsyncStorage.setItem(TASKS_KEY, JSON.stringify(tasks));
+    await syncTasks(tasks);
+  } catch (error) {
+    console.error('Ошибка при сохранении задач', error);
+  }
+};


### PR DESCRIPTION
## Summary
- keep tasks in memory for instant UI updates
- persist task list with new `saveTasksList`

## Testing
- `npm test --prefix TaskManager` *(fails: Cannot find module './ScriptTransformer')*
- `npm run lint --prefix TaskManager` *(fails: Missing script 'lint')*

------
https://chatgpt.com/codex/tasks/task_e_688d29ab40b083239e4968521b88adb0