### PR TITLE
Add loading indicator during font loading

### DIFF
--- a/TaskManager/App.js
+++ b/TaskManager/App.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import * as Notifications from 'expo-notifications';
-import { Provider as PaperProvider } from 'react-native-paper';
+import { Provider as PaperProvider, ActivityIndicator } from 'react-native-paper';
+import { View } from 'react-native';
 import { useFonts, Inter_400Regular, Inter_500Medium } from '@expo-google-fonts/inter';
 import { RobotoFlex_400Regular, RobotoFlex_500Medium } from '@expo-google-fonts/roboto-flex';
 import AppNavigator from './src/navigation/AppNavigator';
@@ -20,7 +21,11 @@ function MainApp() {
   });
 
   if (!fontsLoaded) {
-    return null;
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <ActivityIndicator animating size="large" />
+      </View>
+    );
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- show an `ActivityIndicator` while fonts are loading

## Testing
- `npm test --prefix TaskManager` *(fails: Cannot find module './ScriptTransformer')*

------
https://chatgpt.com/codex/tasks/task_e_688d2f6cbfa083239e36555c13873a3f