### PR TITLE
Switch app to system fonts

### DIFF
--- a/TaskManager/App.js
+++ b/TaskManager/App.js
@@ -1,9 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import * as Notifications from 'expo-notifications';
-import { Provider as PaperProvider, ActivityIndicator } from 'react-native-paper';
-import { View } from 'react-native';
-import { useFonts, Inter_400Regular, Inter_500Medium } from '@expo-google-fonts/inter';
-import { RobotoFlex_400Regular, RobotoFlex_500Medium } from '@expo-google-fonts/roboto-flex';
+import { Provider as PaperProvider } from 'react-native-paper';
 import AppNavigator from './src/navigation/AppNavigator';
 import { registerForPushNotificationsAsync } from './src/services/notificationService';
 import { TaskProvider } from './src/context/TaskContext';
@@ -13,20 +10,6 @@ import SignInScreen from './src/screens/SignInScreen';
 function MainApp() {
   const [user, setUser] = useState(null);
   const { paperTheme } = useThemePreferences();
-  const [fontsLoaded] = useFonts({
-    Inter_400Regular,
-    Inter_500Medium,
-    RobotoFlex_400Regular,
-    RobotoFlex_500Medium,
-  });
-
-  if (!fontsLoaded) {
-    return (
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-        <ActivityIndicator animating size="large" />
-      </View>
-    );
-  }
 
   useEffect(() => {
     // Запрос разрешений на уведомления

--- a/TaskManager/package-lock.json
+++ b/TaskManager/package-lock.json
@@ -8,8 +8,6 @@
       "name": "task-manager",
       "version": "1.0.0",
       "dependencies": {
-        "@expo-google-fonts/inter": "^0.4.1",
-        "@expo-google-fonts/roboto-flex": "^0.4.0",
         "@expo/metro-runtime": "~5.0.4",
         "@react-native-async-storage/async-storage": "2.1.2",
         "@react-native-community/datetimepicker": "8.4.1",
@@ -21,7 +19,6 @@
         "expo": "^53.0.20",
         "expo-auth-session": "^6.2.1",
         "expo-device": "~7.1.4",
-        "expo-font": "^13.3.2",
         "expo-localization": "~16.1.6",
         "expo-notifications": "~0.31.4",
         "expo-status-bar": "~2.2.3",
@@ -2169,18 +2166,6 @@
       "engines": {
         "node": ">=0.8.0"
       }
-    },
-    "node_modules/@expo-google-fonts/inter": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@expo-google-fonts/inter/-/inter-0.4.1.tgz",
-      "integrity": "sha512-ypL+XokTHEG+ie/nxNj/mS38afMrY4Li4oKvTJf9k9XvH7I21qfTGCsDtlZ6nIUWEAy1odoUZISdXT1nfMh4kA==",
-      "license": "MIT AND OFL-1.1"
-    },
-    "node_modules/@expo-google-fonts/roboto-flex": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@expo-google-fonts/roboto-flex/-/roboto-flex-0.4.0.tgz",
-      "integrity": "sha512-G5hfT9gMfVV1GpcScKBBLIMPZCtWnML8xTG5lPebdMrjFFeeEEekqMSh2vRSekBsA8nHWzXdzzkIidkDByYMoA==",
-      "license": "MIT AND OFL-1.1"
     },
     "node_modules/@expo/cli": {
       "version": "0.24.20",

--- a/TaskManager/package.json
+++ b/TaskManager/package.json
@@ -10,8 +10,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "@expo-google-fonts/inter": "^0.4.1",
-    "@expo-google-fonts/roboto-flex": "^0.4.0",
     "@expo/metro-runtime": "~5.0.4",
     "@react-native-async-storage/async-storage": "2.1.2",
     "@react-native-community/datetimepicker": "8.4.1",
@@ -23,7 +21,6 @@
     "expo": "^53.0.20",
     "expo-auth-session": "^6.2.1",
     "expo-device": "~7.1.4",
-    "expo-font": "^13.3.2",
     "expo-localization": "~16.1.6",
     "expo-notifications": "~0.31.4",
     "expo-status-bar": "~2.2.3",

--- a/TaskManager/src/context/ThemeContext.js
+++ b/TaskManager/src/context/ThemeContext.js
@@ -1,12 +1,13 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import { useColorScheme } from 'react-native';
+import { Platform, useColorScheme } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { MD3DarkTheme, MD3LightTheme } from 'react-native-paper';
 
+const systemFont = Platform.select({ ios: 'System', android: 'sans-serif' });
 const baseFonts = {
-  bodyLarge: { ...MD3LightTheme.fonts.bodyLarge, fontFamily: 'Inter_400Regular' },
-  bodyMedium: { ...MD3LightTheme.fonts.bodyMedium, fontFamily: 'Inter_400Regular' },
-  titleLarge: { ...MD3LightTheme.fonts.titleLarge, fontFamily: 'RobotoFlex_500Medium' },
+  bodyLarge: { ...MD3LightTheme.fonts.bodyLarge, fontFamily: systemFont },
+  bodyMedium: { ...MD3LightTheme.fonts.bodyMedium, fontFamily: systemFont },
+  titleLarge: { ...MD3LightTheme.fonts.titleLarge, fontFamily: systemFont },
 };
 
 const createThemes = (accent) => ({

--- a/TaskManager/src/styles/styles.js
+++ b/TaskManager/src/styles/styles.js
@@ -1,4 +1,6 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Platform } from 'react-native';
+
+const systemFont = Platform.select({ ios: 'System', android: 'sans-serif' });
 
 export default StyleSheet.create({
   item: {
@@ -11,12 +13,12 @@ export default StyleSheet.create({
   title: {
     fontSize: 18,
     fontWeight: '500',
-    fontFamily: 'Inter_500Medium',
+    fontFamily: systemFont,
   },
   secondary: {
     fontSize: 14,
     color: '#777',
-    fontFamily: 'Inter_400Regular',
+    fontFamily: systemFont,
   },
   fab: {
   position: 'absolute',
@@ -54,7 +56,7 @@ export default StyleSheet.create({
   detailTitle: {
     fontSize: 20,
     fontWeight: '500',
-    fontFamily: 'RobotoFlex_500Medium',
+    fontFamily: systemFont,
     marginBottom: 12,
   },
 });

--- a/TaskManager/task-manager/app/(tabs)/explore.tsx
+++ b/TaskManager/task-manager/app/(tabs)/explore.tsx
@@ -58,7 +58,7 @@ export default function TabTwoScreen() {
       <Collapsible title="Custom fonts">
         <ThemedText>
           Open <ThemedText type="defaultSemiBold">app/_layout.tsx</ThemedText> to see how to load{' '}
-          <ThemedText style={{ fontFamily: 'SpaceMono' }}>
+          <ThemedText style={{ fontFamily: Platform.select({ ios: 'System', android: 'sans-serif' }) }}>
             custom fonts such as this one.
           </ThemedText>
         </ThemedText>

--- a/TaskManager/task-manager/app/_layout.tsx
+++ b/TaskManager/task-manager/app/_layout.tsx
@@ -1,5 +1,4 @@
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
-import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
@@ -8,14 +7,6 @@ import { useColorScheme } from '@/hooks/useColorScheme';
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
-  const [loaded] = useFonts({
-    SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
-  });
-
-  if (!loaded) {
-    // Async font loading only occurs in development.
-    return null;
-  }
 
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>

--- a/TaskManager/task-manager/package-lock.json
+++ b/TaskManager/task-manager/package-lock.json
@@ -15,7 +15,6 @@
         "expo": "~53.0.20",
         "expo-blur": "~14.1.5",
         "expo-constants": "~17.1.7",
-        "expo-font": "~13.3.2",
         "expo-haptics": "~14.1.4",
         "expo-image": "~2.4.0",
         "expo-linking": "~7.1.7",

--- a/TaskManager/task-manager/package.json
+++ b/TaskManager/task-manager/package.json
@@ -18,7 +18,6 @@
     "expo": "~53.0.20",
     "expo-blur": "~14.1.5",
     "expo-constants": "~17.1.7",
-    "expo-font": "~13.3.2",
     "expo-haptics": "~14.1.4",
     "expo-image": "~2.4.0",
     "expo-linking": "~7.1.7",


### PR DESCRIPTION
## Summary
- drop custom font loading logic
- use system fonts on iOS and Android
- remove unused font packages

## Testing
- `npm test` *(fails: Cannot find module './ScriptTransformer')*

------
https://chatgpt.com/codex/tasks/task_e_688d36b4c8248323a822171b6d868958