### PR TITLE
Add unified settings menu and global fonts

### DIFF
--- a/TaskManager/src/components/TaskItem.js
+++ b/TaskManager/src/components/TaskItem.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { View, Text } from 'react-native';
-import { Card, IconButton, Badge, Avatar } from 'react-native-paper';
+import { View } from 'react-native';
+import { Card, IconButton, Badge, Avatar, Text } from 'react-native-paper';
 import styles from '../styles/styles';
 import formatDate from '../utils/formatDate';
 

--- a/TaskManager/src/context/ThemeContext.js
+++ b/TaskManager/src/context/ThemeContext.js
@@ -4,16 +4,15 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { MD3DarkTheme, MD3LightTheme } from 'react-native-paper';
 
 const systemFont = Platform.select({ ios: 'System', android: 'sans-serif' });
-const baseFonts = {
-  bodyLarge: { ...MD3LightTheme.fonts.bodyLarge, fontFamily: systemFont },
-  bodyMedium: { ...MD3LightTheme.fonts.bodyMedium, fontFamily: systemFont },
-  titleLarge: { ...MD3LightTheme.fonts.titleLarge, fontFamily: systemFont },
-};
+const baseFonts = {};
+Object.keys(MD3LightTheme.fonts).forEach((k) => {
+  baseFonts[k] = { ...MD3LightTheme.fonts[k], fontFamily: systemFont };
+});
 
 const createThemes = (accent) => ({
   light: {
     ...MD3LightTheme,
-    fonts: { ...MD3LightTheme.fonts, ...baseFonts },
+    fonts: baseFonts,
     colors: {
       ...MD3LightTheme.colors,
       primary: accent,
@@ -26,7 +25,7 @@ const createThemes = (accent) => ({
   },
   dark: {
     ...MD3DarkTheme,
-    fonts: { ...MD3DarkTheme.fonts, ...baseFonts },
+    fonts: baseFonts,
     colors: {
       ...MD3DarkTheme.colors,
       primary: accent,

--- a/TaskManager/src/navigation/AppNavigator.js
+++ b/TaskManager/src/navigation/AppNavigator.js
@@ -5,6 +5,7 @@ import TaskListScreen from '../screens/TaskListScreen';
 import TaskFormScreen from '../screens/TaskFormScreen';
 import TaskDetailScreen from '../screens/TaskDetailScreen';
 import SettingsScreen from '../screens/SettingsScreen';
+import AboutScreen from '../screens/AboutScreen';
 import i18n from '../i18n';
 
 const Stack = createStackNavigator();
@@ -23,6 +24,7 @@ export default function AppNavigator() {
         />
         <Stack.Screen name="TaskDetail" component={TaskDetailScreen} options={{ title: i18n.t('taskDetails') }} />
         <Stack.Screen name="Settings" component={SettingsScreen} options={{ title: i18n.t('settings') }} />
+        <Stack.Screen name="About" component={AboutScreen} options={{ title: 'О приложении' }} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/TaskManager/src/screens/AboutScreen.js
+++ b/TaskManager/src/screens/AboutScreen.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { View } from 'react-native';
+import { Text, useTheme } from 'react-native-paper';
+import Constants from 'expo-constants';
+
+export default function AboutScreen() {
+  const theme = useTheme();
+  const version = Constants.expoConfig?.version || '1.0.0';
+  return (
+    <View style={{ flex: 1, padding: 16, backgroundColor: theme.colors.background }}>
+      <Text variant="titleLarge" style={{ marginBottom: 8 }}>О приложении</Text>
+      <Text>Версия: {version}</Text>
+      <Text style={{ marginTop: 8 }}>Task Manager - приложение для управления задачами.</Text>
+    </View>
+  );
+}

--- a/TaskManager/src/screens/TaskListScreen.js
+++ b/TaskManager/src/screens/TaskListScreen.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { View, FlatList } from 'react-native';
-import { FAB, Appbar, Menu, Searchbar, Text, Button } from 'react-native-paper';
+import { FAB, Appbar, Menu, Searchbar, Text, Button, Divider } from 'react-native-paper';
 import { useIsFocused } from '@react-navigation/native';
 import { useTasks } from '../context/TaskContext';
 import { useThemePreferences } from '../context/ThemeContext';
@@ -9,17 +9,17 @@ import { TASK_STATUSES } from '../constants';
 import TaskItem from '../components/TaskItem';
 import TaskWidget from '../components/TaskWidget';
 import styles from '../styles/styles';
-import { Divider } from 'react-native-paper';
 
 export default function TaskListScreen({ navigation }) {
   const { tasks: storedTasks, togglePin } = useTasks();
   const { theme, toggleTheme, paperTheme } = useThemePreferences();
   const [tasks, setTasks] = useState([]);
-  const [menuVisible, setMenuVisible] = useState(false);
-  const [filterMenuVisible, setFilterMenuVisible] = useState(false);
+  const [settingsVisible, setSettingsVisible] = useState(false);
+  const [notificationsEnabled, setNotificationsEnabled] = useState(true);
   const [sortType, setSortType] = useState('date'); // date | status
   const [filterStatus, setFilterStatus] = useState('all');
   const [searchQuery, setSearchQuery] = useState('');
+  const [language, setLanguage] = useState(i18n.locale);
   const isFocused = useIsFocused();
 
   useEffect(() => {
@@ -55,12 +55,12 @@ export default function TaskListScreen({ navigation }) {
   const changeSort = (type) => {
     setSortType(type);
     setTasks(sortTasks(tasks, type));
-    setMenuVisible(false);
+    setSettingsVisible(false);
   };
 
   const changeFilter = (status) => {
     setFilterStatus(status);
-    setFilterMenuVisible(false);
+    setSettingsVisible(false);
   };
 
   const handleTogglePin = async (id) => {
@@ -75,39 +75,25 @@ export default function TaskListScreen({ navigation }) {
       {/* Appbar с меню сортировки */}
       <Appbar.Header>
         <Appbar.Content title={i18n.t('taskList')} />
-        <Appbar.Action icon="cog" onPress={() => navigation.navigate('Settings')} />
         <Menu
-          visible={menuVisible}
-          onDismiss={() => setMenuVisible(false)}
-          anchor={
-            <Appbar.Action
-              icon="sort"
-              onPress={() => setMenuVisible(true)}
-            />
-          }
+          visible={settingsVisible}
+          onDismiss={() => setSettingsVisible(false)}
+          anchor={<Appbar.Action icon="hexagon-outline" onPress={() => setSettingsVisible(true)} />}
         >
           <Menu.Item onPress={() => changeSort('date')} title="Сортировать по дате" />
           <Menu.Item onPress={() => changeSort('status')} title="Сортировать по статусу" />
-        </Menu>
-        <Menu
-          visible={filterMenuVisible}
-          onDismiss={() => setFilterMenuVisible(false)}
-          anchor={
-            <Appbar.Action
-              icon="filter"
-              onPress={() => setFilterMenuVisible(true)}
-            />
-          }
-        >
+          <Divider />
           <Menu.Item onPress={() => changeFilter('all')} title="Все" />
           <Menu.Item onPress={() => changeFilter(TASK_STATUSES[0])} title="Активные" />
           <Menu.Item onPress={() => changeFilter(TASK_STATUSES[1])} title="Завершённые" />
           <Menu.Item onPress={() => changeFilter(TASK_STATUSES[2])} title="Отменённые" />
+          <Divider />
+          <Menu.Item onPress={toggleTheme} title={theme === 'light' ? 'Тёмная тема' : 'Светлая тема'} />
+          <Menu.Item onPress={() => setNotificationsEnabled(!notificationsEnabled)} title={notificationsEnabled ? 'Отключить уведомления' : 'Включить уведомления'} />
+          <Menu.Item onPress={() => { const lang = language === 'ru' ? 'en' : 'ru'; i18n.locale = lang; setLanguage(lang); }} title={language === 'ru' ? 'Switch to English' : 'Переключить на русский'} />
+          <Menu.Item onPress={() => { setSettingsVisible(false); navigation.navigate('About'); }} title="О приложении" />
+          <Menu.Item onPress={() => { setSettingsVisible(false); navigation.navigate('Settings'); }} title="Расширенные настройки" />
         </Menu>
-        <Appbar.Action
-          icon={theme === 'light' ? 'weather-night' : 'white-balance-sunny'}
-          onPress={toggleTheme}
-        />
       </Appbar.Header>
 
       <Searchbar

--- a/TaskManager/src/styles/styles.js
+++ b/TaskManager/src/styles/styles.js
@@ -1,6 +1,4 @@
-import { StyleSheet, Platform } from 'react-native';
-
-const systemFont = Platform.select({ ios: 'System', android: 'sans-serif' });
+import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
   item: {
@@ -13,12 +11,10 @@ export default StyleSheet.create({
   title: {
     fontSize: 18,
     fontWeight: '500',
-    fontFamily: systemFont,
   },
   secondary: {
     fontSize: 14,
     color: '#777',
-    fontFamily: systemFont,
   },
   fab: {
   position: 'absolute',
@@ -56,7 +52,6 @@ export default StyleSheet.create({
   detailTitle: {
     fontSize: 20,
     fontWeight: '500',
-    fontFamily: systemFont,
     marginBottom: 12,
   },
 });


### PR DESCRIPTION
## Summary
- configure fonts globally in `ThemeProvider`
- clean up style-specific fonts
- use Paper `Text` in `TaskItem`
- add single settings menu with sorting, filtering, theming and more
- create basic `AboutScreen`
- register screen in navigation

## Testing
- `npm install`
- `npm test` *(fails: Cannot find module './ScriptTransformer')*

------
https://chatgpt.com/codex/tasks/task_e_688d3a1108908323afab292601d1a6c7