### PR TITLE
Fix sorting update and improve badge readability

### DIFF
--- a/TaskManager/src/components/TaskItem.js
+++ b/TaskManager/src/components/TaskItem.js
@@ -59,7 +59,7 @@ const TaskItem = ({ task, onPress, onToggle, onLongPress }) => (
           <Text style={styles.title}>{task.title}</Text>
           <Text style={styles.secondary}>{formatDate(task.date)}</Text>
           <Text style={styles.secondary}>{task.category}</Text>
-          <Badge style={{ backgroundColor: badgeColor(task.status), alignSelf: 'flex-start', marginTop: 4 }}>
+          <Badge style={{ backgroundColor: badgeColor(task.status), alignSelf: 'flex-start', marginTop: 4, color: 'white' }}>
             {task.status}
           </Badge>
         </View>

--- a/TaskManager/src/screens/TaskListScreen.js
+++ b/TaskManager/src/screens/TaskListScreen.js
@@ -36,7 +36,7 @@ export default function TaskListScreen({ navigation }) {
     if (isFocused) {
       updateList();
     }
-  }, [isFocused, filterStatus, searchQuery, storedTasks]);
+  }, [isFocused, filterStatus, searchQuery, storedTasks, sortType]);
 
   const updateList = () => {
     let list = storedTasks || [];


### PR DESCRIPTION
## Summary
- keep task list sorted when sort type changes
- improve status badge readability with white text

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npm test --silent` *(fails: Cannot find module './ScriptTransformer')*
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_688d4353e1448323bc3d3390059a67f3