### PR TITLE
Implement monthly views and improve theme handling

### DIFF
--- a/TaskManager/src/navigation/AppNavigator.js
+++ b/TaskManager/src/navigation/AppNavigator.js
@@ -6,6 +6,7 @@ import TaskFormScreen from '../screens/TaskFormScreen';
 import TaskDetailScreen from '../screens/TaskDetailScreen';
 import SettingsScreen from '../screens/SettingsScreen';
 import AboutScreen from '../screens/AboutScreen';
+import MonthTasksScreen from '../screens/MonthTasksScreen';
 import i18n from '../i18n';
 
 const Stack = createStackNavigator();
@@ -25,6 +26,11 @@ export default function AppNavigator() {
         <Stack.Screen name="TaskDetail" component={TaskDetailScreen} options={{ title: i18n.t('taskDetails') }} />
         <Stack.Screen name="Settings" component={SettingsScreen} options={{ title: i18n.t('settings') }} />
         <Stack.Screen name="About" component={AboutScreen} options={{ title: 'О приложении' }} />
+        <Stack.Screen
+          name="MonthTasks"
+          component={MonthTasksScreen}
+          options={({ route }) => ({ title: route.params?.title || 'Задачи' })}
+        />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/TaskManager/src/screens/MonthTasksScreen.js
+++ b/TaskManager/src/screens/MonthTasksScreen.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { View, FlatList } from 'react-native';
+import { useTheme } from 'react-native-paper';
+import { useTasks } from '../context/TaskContext';
+import { List, Text } from 'react-native-paper';
+
+export default function MonthTasksScreen({ route }) {
+  const { monthOffset = 0, title } = route.params || {};
+  const { tasks } = useTasks();
+  const paper = useTheme();
+
+  const now = new Date();
+  const target = new Date(now.getFullYear(), now.getMonth() + monthOffset, 1);
+  const month = target.getMonth();
+  const year = target.getFullYear();
+
+  const monthTasks = tasks
+    .filter((t) => {
+      const d = new Date(t.date);
+      return d.getMonth() === month && d.getFullYear() === year;
+    })
+    .sort((a, b) => new Date(a.date) - new Date(b.date));
+
+  return (
+    <View style={{ flex: 1, backgroundColor: paper.colors.background }}>
+      <FlatList
+        data={monthTasks}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <List.Item
+            title={item.title}
+            description={new Date(item.date).toLocaleDateString()}
+          />
+        )}
+        ListEmptyComponent={<Text style={{ margin: 16 }}>Нет задач</Text>}
+      />
+    </View>
+  );
+}

--- a/TaskManager/src/screens/TaskFormScreen.js
+++ b/TaskManager/src/screens/TaskFormScreen.js
@@ -146,12 +146,13 @@ export default function TaskFormScreen({ navigation, route }) {
         style={styles.input}
       />
       {showDatePicker && (
-        <DateTimePicker
-          value={date ? new Date(`${date}T00:00:00`) : new Date()}
-          mode="date"
-          display={Platform.OS === 'ios' ? 'spinner' : 'default'}
-          onChange={onDateChange}
-        />
+      <DateTimePicker
+        value={date ? new Date(`${date}T00:00:00`) : new Date()}
+        mode="date"
+        display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+        themeVariant={paperTheme.dark ? 'dark' : 'light'}
+        onChange={onDateChange}
+      />
       )}
 
       <TextInput
@@ -163,12 +164,13 @@ export default function TaskFormScreen({ navigation, route }) {
         style={styles.input}
       />
       {showTimePicker && (
-        <DateTimePicker
-          value={time ? new Date(`1970-01-01T${time}:00`) : new Date()}
-          mode="time"
-          display={Platform.OS === 'ios' ? 'spinner' : 'default'}
-          onChange={onTimeChange}
-        />
+      <DateTimePicker
+        value={time ? new Date(`1970-01-01T${time}:00`) : new Date()}
+        mode="time"
+        display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+        themeVariant={paperTheme.dark ? 'dark' : 'light'}
+        onChange={onTimeChange}
+      />
       )}
       <TextInput
         mode="outlined"

--- a/TaskManager/src/screens/TaskListScreen.js
+++ b/TaskManager/src/screens/TaskListScreen.js
@@ -83,7 +83,14 @@ export default function TaskListScreen({ navigation }) {
   return (
     <View style={{ flex: 1, backgroundColor: paperTheme.colors.background }}>
       {/* Appbar с меню сортировки */}
-      <Appbar.Header>
+      <Appbar.Header style={{ height: 48 }}>
+        <Appbar.Action
+          icon={theme === 'light' ? 'weather-night' : 'white-balance-sunny'}
+          onPress={() => {
+            toggleTheme();
+            setSnackbar('Тема изменена');
+          }}
+        />
         <Appbar.Content title={i18n.t('taskList')} />
         <Menu
           visible={settingsVisible}
@@ -130,6 +137,28 @@ export default function TaskListScreen({ navigation }) {
           <Menu.Item onPress={() => changeFilter(TASK_STATUSES[0])} title="Активные" />
           <Menu.Item onPress={() => changeFilter(TASK_STATUSES[1])} title="Завершённые" />
           <Menu.Item onPress={() => changeFilter(TASK_STATUSES[2])} title="Отменённые" />
+          <Divider />
+          <Menu.Item title="По месяцам" disabled />
+          <Menu.Item
+            onPress={() => {
+              setSettingsVisible(false);
+              navigation.navigate('MonthTasks', {
+                monthOffset: 0,
+                title: 'Этот месяц',
+              });
+            }}
+            title="Этот месяц"
+          />
+          <Menu.Item
+            onPress={() => {
+              setSettingsVisible(false);
+              navigation.navigate('MonthTasks', {
+                monthOffset: 1,
+                title: 'Следующий месяц',
+              });
+            }}
+            title="Следующий месяц"
+          />
           <Divider />
           <Menu.Item title="Система" disabled />
           <Menu.Item onPress={() => setNotificationsEnabled(!notificationsEnabled)} title={notificationsEnabled ? 'Отключить уведомления' : 'Включить уведомления'} />


### PR DESCRIPTION
## Summary
- add MonthTasksScreen to show tasks by month
- wire new screen into navigator
- allow quick theme toggle from top-left icon
- add menu links for month filters
- adjust AppBar header height
- fix DateTimePicker colors in dark theme

## Testing
- `npm install`
- `npm test --silent` *(fails: Cannot find module './ScriptTransformer')*

------
https://chatgpt.com/codex/tasks/task_e_688d4a44d2d8832393ecfd4575d95ac3