### PR TITLE
Add mini calendar with task markers

### DIFF
--- a/TaskManager/package-lock.json
+++ b/TaskManager/package-lock.json
@@ -21,13 +21,14 @@
         "expo-device": "~7.1.4",
         "expo-localization": "~16.1.6",
         "expo-notifications": "~0.31.4",
-        "expo-print": "^14.1.4",
+        "expo-print": "~14.1.4",
         "expo-sharing": "^13.1.5",
         "expo-status-bar": "~2.2.3",
         "i18n-js": "^4.5.1",
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-native": "0.79.5",
+        "react-native-calendars": "^1.1313.0",
         "react-native-gesture-handler": "~2.24.0",
         "react-native-markdown-display": "^7.0.2",
         "react-native-paper": "^5.12.3",
@@ -8651,6 +8652,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -9617,6 +9628,38 @@
         }
       }
     },
+    "node_modules/react-native-calendars": {
+      "version": "1.1313.0",
+      "resolved": "https://registry.npmjs.org/react-native-calendars/-/react-native-calendars-1.1313.0.tgz",
+      "integrity": "sha512-YQ7Vg57rBRVymolamYDTxZ0lPOELTDHQbTukTWdxR47aRBYJwKI6ocRbwcY5gYgyDwNgJS4uLGu5AvmYS74LYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.1",
+        "lodash": "^4.17.15",
+        "memoize-one": "^5.2.1",
+        "prop-types": "^15.5.10",
+        "react-native-safe-area-context": "4.5.0",
+        "react-native-swipe-gestures": "^1.0.5",
+        "recyclerlistview": "^4.0.0",
+        "xdate": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "moment": "^2.29.4"
+      }
+    },
+    "node_modules/react-native-calendars/node_modules/react-native-safe-area-context": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.5.0.tgz",
+      "integrity": "sha512-0WORnk9SkREGUg2V7jHZbuN5x4vcxj/1B0QOcXJjdYWrzZHgLcUzYWWIUecUPJh747Mwjt/42RZDOaFn3L8kPQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-edge-to-edge": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/react-native-edge-to-edge/-/react-native-edge-to-edge-1.6.0.tgz",
@@ -9781,6 +9824,12 @@
         "react": "*",
         "react-native": "*"
       }
+    },
+    "node_modules/react-native-swipe-gestures": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/react-native-swipe-gestures/-/react-native-swipe-gestures-1.0.5.tgz",
+      "integrity": "sha512-Ns7Bn9H/Tyw278+5SQx9oAblDZ7JixyzeOczcBK8dipQk2pD7Djkcfnf1nB/8RErAmMLL9iXgW0QHqiII8AhKw==",
+      "license": "MIT"
     },
     "node_modules/react-native-vector-icons": {
       "version": "10.3.0",
@@ -10004,6 +10053,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/recyclerlistview": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/recyclerlistview/-/recyclerlistview-4.2.3.tgz",
+      "integrity": "sha512-STR/wj/FyT8EMsBzzhZ1l2goYirMkIgfV3gYEPxI3Kf3lOnu6f7Dryhyw7/IkQrgX5xtTcDrZMqytvteH9rL3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.debounce": "4.0.8",
+        "prop-types": "15.8.1",
+        "ts-object-utils": "0.0.5"
+      },
+      "peerDependencies": {
+        "react": ">= 15.2.1",
+        "react-native": ">= 0.30.0"
       }
     },
     "node_modules/regenerate": {
@@ -11205,6 +11269,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
+    "node_modules/ts-object-utils": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/ts-object-utils/-/ts-object-utils-0.0.5.tgz",
+      "integrity": "sha512-iV0GvHqOmilbIKJsfyfJY9/dNHCs969z3so90dQWsO1eMMozvTpnB1MEaUbb3FYtZTGjv5sIy/xmslEz0Rg2TA==",
+      "license": "ISC"
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -11724,6 +11794,12 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/xdate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/xdate/-/xdate-0.8.3.tgz",
+      "integrity": "sha512-1NhJWPJwN+VjbkACT9XHbQK4o6exeSVtS2CxhMPwUE7xQakoEFTlwra9YcqV/uHQVyeEUYoYC46VGDJ+etnIiw==",
+      "license": "(MIT OR GPL-2.0)"
     },
     "node_modules/xml2js": {
       "version": "0.6.0",

--- a/TaskManager/package.json
+++ b/TaskManager/package.json
@@ -23,13 +23,14 @@
     "expo-device": "~7.1.4",
     "expo-localization": "~16.1.6",
     "expo-notifications": "~0.31.4",
-    "expo-print": "^14.1.4",
+    "expo-print": "~14.1.4",
     "expo-sharing": "^13.1.5",
     "expo-status-bar": "~2.2.3",
     "i18n-js": "^4.5.1",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.5",
+    "react-native-calendars": "^1.1313.0",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-markdown-display": "^7.0.2",
     "react-native-paper": "^5.12.3",
@@ -38,8 +39,7 @@
     "react-native-screens": "~4.11.1",
     "react-native-vector-icons": "^10.0.3",
     "react-native-web": "^0.20.0",
-    "typescript": "~5.8.3",
-    "expo-print": "~14.1.4"
+    "typescript": "~5.8.3"
   },
   "devDependencies": {
     "@babel/core": "^7.24.0",

--- a/TaskManager/src/components/MiniCalendar.js
+++ b/TaskManager/src/components/MiniCalendar.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Calendar, LocaleConfig } from 'react-native-calendars';
+import { useTheme } from 'react-native-paper';
+
+LocaleConfig.locales.ru = {
+  monthNames: ['Январь','Февраль','Март','Апрель','Май','Июнь','Июль','Август','Сентябрь','Октябрь','Ноябрь','Декабрь'],
+  monthNamesShort: ['Янв','Фев','Мар','Апр','Май','Июн','Июл','Авг','Сен','Окт','Ноя','Дек'],
+  dayNames: ['Воскресенье','Понедельник','Вторник','Среда','Четверг','Пятница','Суббота'],
+  dayNamesShort: ['Вс','Пн','Вт','Ср','Чт','Пт','Сб'],
+  today: 'Сегодня',
+};
+LocaleConfig.defaultLocale = 'ru';
+
+export default function MiniCalendar({ tasks, monthDate, selectedDate, onSelectDate, onChangeMonth }) {
+  const paper = useTheme();
+
+  const marked = tasks.reduce((acc, task) => {
+    const date = new Date(task.date).toISOString().split('T')[0];
+    acc[date] = {
+      ...(acc[date] || {}),
+      marked: true,
+      dotColor: paper.colors.primary,
+    };
+    return acc;
+  }, {});
+
+  if (selectedDate) {
+    marked[selectedDate] = {
+      ...(marked[selectedDate] || {}),
+      selected: true,
+      selectedColor: paper.colors.primary,
+    };
+  }
+
+  return (
+    <Calendar
+      current={monthDate.toISOString().split('T')[0]}
+      onMonthChange={(m) => onChangeMonth(new Date(m.year, m.month - 1, 1))}
+      onDayPress={(day) => onSelectDate(day.dateString)}
+      markedDates={marked}
+      hideExtraDays
+      firstDay={1}
+      enableSwipeMonths
+      theme={{
+        todayTextColor: paper.colors.primary,
+        selectedDayBackgroundColor: paper.colors.primary,
+        arrowColor: paper.colors.primary,
+      }}
+      style={{ marginBottom: 8 }}
+    />
+  );
+}

--- a/TaskManager/src/screens/MonthTasksScreen.js
+++ b/TaskManager/src/screens/MonthTasksScreen.js
@@ -8,6 +8,7 @@ import * as FileSystem from 'expo-file-system';
 import { useTasks } from '../context/TaskContext';
 import { TASK_STATUSES } from '../constants';
 import styles from '../styles/styles';
+import MiniCalendar from '../components/MiniCalendar';
 
 export default function MonthTasksScreen({ route, navigation }) {
   const { monthOffset = 0 } = route.params || {};
@@ -19,6 +20,7 @@ export default function MonthTasksScreen({ route, navigation }) {
 
   const [monthDate, setMonthDate] = useState(initial);
   const [showPicker, setShowPicker] = useState(false);
+  const [selectedDate, setSelectedDate] = useState(null);
 
   const month = monthDate.getMonth();
   const year = monthDate.getFullYear();
@@ -30,9 +32,16 @@ export default function MonthTasksScreen({ route, navigation }) {
     })
     .sort((a, b) => new Date(a.date) - new Date(b.date));
 
+  const displayTasks = selectedDate
+    ? monthTasks.filter(
+        (t) =>
+          new Date(t.date).toISOString().split('T')[0] === selectedDate,
+      )
+    : monthTasks;
+
   const sections = TASK_STATUSES.map((status) => ({
     title: status,
-    data: monthTasks.filter((t) => t.status === status),
+    data: displayTasks.filter((t) => t.status === status),
   }));
 
   const monthLabel = monthDate.toLocaleDateString('ru-RU', {
@@ -76,9 +85,10 @@ export default function MonthTasksScreen({ route, navigation }) {
   };
 
   const highlightStyle = (date) => {
-    const today = new Date();
     const d = new Date(date);
-    if (d.toDateString() === today.toDateString()) {
+    const dayString = d.toISOString().split('T')[0];
+    const today = new Date().toISOString().split('T')[0];
+    if (dayString === today || dayString === selectedDate) {
       return { backgroundColor: '#e3f2fd' };
     }
     return null;
@@ -100,6 +110,18 @@ export default function MonthTasksScreen({ route, navigation }) {
           onChange={onChangeDate}
         />
       )}
+      <MiniCalendar
+        tasks={monthTasks}
+        monthDate={monthDate}
+        selectedDate={selectedDate}
+        onSelectDate={(d) =>
+          setSelectedDate((prev) => (prev === d ? null : d))
+        }
+        onChangeMonth={(d) => {
+          setMonthDate(d);
+          setSelectedDate(null);
+        }}
+      />
       <SectionList
         sections={sections}
         keyExtractor={(item) => item.id}


### PR DESCRIPTION
## Summary
- add `react-native-calendars` dependency
- implement `MiniCalendar` component showing dots on days with tasks
- integrate mini calendar into `MonthTasksScreen`

## Testing
- `npm test` *(fails: Cannot find module './ScriptTransformer')*

------
https://chatgpt.com/codex/tasks/task_e_688d5414acf083239142c7444116fdb6