### PR TITLE
feat: enhance dark theme and task list styling

### DIFF
--- a/TaskManager/src/components/TaskItem.js
+++ b/TaskManager/src/components/TaskItem.js
@@ -1,30 +1,19 @@
 import React from 'react';
 import { View } from 'react-native';
-import { Card, IconButton, Avatar, Text } from 'react-native-paper';
+import { Card, IconButton, Avatar, Text, Badge } from 'react-native-paper';
 import styles from '../styles/styles';
 import formatDate from '../utils/formatDate';
 
 // navigation should be handled by the parent component. This component accepts
 // an onPress callback so that it can be reused in different contexts.
-const statusIcon = (status) => {
-  switch (status) {
-    case 'Завершена':
-      return 'check-circle-outline';
-    case 'Отменена':
-      return 'close-circle-outline';
-    default:
-      return 'progress-clock';
-  }
-};
-
 const statusColor = (status) => {
   switch (status) {
     case 'Завершена':
-      return 'green';
+      return '#4CAF50';
     case 'Отменена':
-      return 'gray';
+      return '#9E9E9E';
     default:
-      return 'blue';
+      return '#4A90E2';
   }
 };
 
@@ -40,19 +29,22 @@ const categoryIcon = (category) => {
 };
 
 const TaskItem = ({ task, onPress, onToggle, onLongPress }) => (
-  <Card style={styles.item} onPress={onPress} onLongPress={onLongPress} mode="outlined">
+  <Card style={styles.item} onPress={onPress} onLongPress={onLongPress} mode="elevated">
     <Card.Content style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
       <View style={{ flexDirection: 'row', alignItems: 'center', flex: 1 }}>
         <Avatar.Icon size={28} icon={categoryIcon(task.category)} style={{ marginRight: 8 }} />
         <View style={{ flex: 1 }}>
           <View style={{ flexDirection: 'row', alignItems: 'center', flexWrap: 'wrap' }}>
             <Text style={styles.title}>{task.title}</Text>
-            <IconButton
-              icon={statusIcon(task.status)}
-              iconColor={statusColor(task.status)}
-              size={16}
-              style={{ margin: 0, marginLeft: 4 }}
-            />
+            <Badge
+              style={{
+                backgroundColor: statusColor(task.status),
+                color: '#FFFFFF',
+                marginLeft: 4,
+              }}
+            >
+              {task.status}
+            </Badge>
           </View>
           <Text style={styles.secondary}>{formatDate(task.date)}</Text>
         </View>

--- a/TaskManager/src/context/ThemeContext.js
+++ b/TaskManager/src/context/ThemeContext.js
@@ -5,7 +5,8 @@ import { MD3DarkTheme, MD3LightTheme } from 'react-native-paper';
 
 const systemFont = Platform.select({ ios: 'System', android: 'sans-serif' });
 const baseFonts = {};
-const DEFAULT_ACCENT = Platform.select({ ios: '#007AFF', android: '#6200EE', default: '#1F2937' });
+// Default accent aligns with design spec (#4A90E2)
+const DEFAULT_ACCENT = '#4A90E2';
 Object.keys(MD3LightTheme.fonts).forEach((k) => {
   baseFonts[k] = { ...MD3LightTheme.fonts[k], fontFamily: systemFont };
 });
@@ -22,6 +23,7 @@ const createThemes = (accent) => ({
       surface: '#F5F5F5',
       onBackground: '#000000',
       onSurface: '#000000',
+      onSurfaceVariant: '#555555',
     },
   },
   dark: {
@@ -31,10 +33,11 @@ const createThemes = (accent) => ({
       ...MD3DarkTheme.colors,
       primary: accent,
       secondary: accent,
-      background: '#000000',
+      background: '#1E1E1E',
       surface: '#121212',
       onBackground: '#FFFFFF',
       onSurface: '#FFFFFF',
+      onSurfaceVariant: '#B0B0B0',
     },
   },
 });

--- a/TaskManager/src/styles/styles.js
+++ b/TaskManager/src/styles/styles.js
@@ -2,12 +2,11 @@ import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
   item: {
-    marginVertical: 2,
+    marginVertical: 4,
     borderRadius: 8,
-    borderWidth: 1,
-    borderColor: '#e0e0e0',
-    elevation: 0,
-    paddingVertical: 4,
+    elevation: 1,
+    paddingVertical: 8,
+    height: 64,
   },
   title: {
     fontSize: 16,
@@ -15,7 +14,7 @@ export default StyleSheet.create({
   },
   secondary: {
     fontSize: 12,
-    color: '#777',
+    color: '#B0B0B0',
   },
   fab: {
   position: 'absolute',


### PR DESCRIPTION
## Summary
- adjust default accent and dark theme colors
- streamline task item cards with compact design and status badges

## Testing
- `npm test` (fails: Cannot find module './ScriptTransformer')

------
https://chatgpt.com/codex/tasks/task_e_688dd160a0148323aa4c368c48d4d50f