### PR TITLE
refactor: replace custom switch with native iOS switch

### DIFF
--- a/TaskManager/package-lock.json
+++ b/TaskManager/package-lock.json
@@ -36,7 +36,6 @@
         "react-native-reanimated": "~3.17.4",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1",
-        "react-native-switch": "^1.5.1",
         "react-native-vector-icons": "^10.0.3",
         "react-native-web": "^0.20.0",
         "typescript": "~5.8.3"
@@ -9842,18 +9841,6 @@
       "resolved": "https://registry.npmjs.org/react-native-swipe-gestures/-/react-native-swipe-gestures-1.0.5.tgz",
       "integrity": "sha512-Ns7Bn9H/Tyw278+5SQx9oAblDZ7JixyzeOczcBK8dipQk2pD7Djkcfnf1nB/8RErAmMLL9iXgW0QHqiII8AhKw==",
       "license": "MIT"
-    },
-    "node_modules/react-native-switch": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/react-native-switch/-/react-native-switch-1.5.1.tgz",
-      "integrity": "sha512-nfuPrrPKzeZL1mQH0u1rlEGv9W1+okU/xOcNNaDNz/LhSdzWOZ04ogJ4iEj7Sth3hkBxv4XwFQZTgCc07we+cg==",
-      "license": "MIT",
-      "dependencies": {
-        "prop-types": "^15.6.0"
-      },
-      "peerDependencies": {
-        "react-native": ">=0.29"
-      }
     },
     "node_modules/react-native-vector-icons": {
       "version": "10.3.0",

--- a/TaskManager/package.json
+++ b/TaskManager/package.json
@@ -38,7 +38,6 @@
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
-    "react-native-switch": "^1.5.1",
     "react-native-vector-icons": "^10.0.3",
     "react-native-web": "^0.20.0",
     "typescript": "~5.8.3"

--- a/TaskManager/src/components/IOSSwitch.js
+++ b/TaskManager/src/components/IOSSwitch.js
@@ -1,36 +1,15 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
-import Switch from 'react-native-switch';
+import { Switch } from 'react-native';
 
-const IOSSwitch = ({ value, onValueChange, style, ...props }) => (
+const IOSSwitch = ({ value, onValueChange, ...props }) => (
   <Switch
     value={value}
     onValueChange={onValueChange}
-    backgroundActive="#4A90E2"
-    backgroundInactive="#B0B0B0"
-    circleActiveColor="#ffffff"
-    circleInActiveColor="#ffffff"
-    renderActiveText={false}
-    renderInActiveText={false}
-    barHeight={26}
-    circleSize={30}
-    switchLeftPx={2}
-    switchRightPx={2}
-    switchWidthMultiplier={2}
-    innerCircleStyle={styles.innerCircle}
-    style={style}
+    trackColor={{ false: '#767577', true: '#4A90E2' }}
+    thumbColor={value ? '#ffffff' : '#f4f3f4'}
+    ios_backgroundColor="#3e3e3e"
     {...props}
   />
 );
-
-const styles = StyleSheet.create({
-  innerCircle: {
-    elevation: 2,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.3,
-    shadowRadius: 1.5,
-  },
-});
 
 export default IOSSwitch;


### PR DESCRIPTION
## Summary
- replace custom switch component with `react-native` `Switch`
- drop `react-native-switch` dependency

## Testing
- `npm test` *(fails: Cannot find module './ScriptTransformer')*

------
https://chatgpt.com/codex/tasks/task_e_688dd769e5c08323a527e4e5812727fd