### PR TITLE
feat: improve iOS date picker with done button

### DIFF
--- a/TaskManager/src/components/IOSDatePicker.js
+++ b/TaskManager/src/components/IOSDatePicker.js
@@ -1,18 +1,75 @@
-import React from 'react';
-import DatePicker from 'react-native-date-picker';
+import React, { useState, useEffect } from 'react';
+import { Modal, View, StyleSheet } from 'react-native';
+import DateTimePicker from '@react-native-community/datetimepicker';
+import { Button } from 'react-native-paper';
 
-const IOSDatePicker = ({ open, date, mode, onConfirm, onCancel, dark }) => (
-  <DatePicker
-    modal
-    open={open}
-    date={date}
-    mode={mode}
-    onConfirm={onConfirm}
-    onCancel={onCancel}
-    confirmText="Готово"
-    cancelText="Отмена"
-    theme={dark ? 'dark' : 'light'}
-  />
-);
+const IOSDatePicker = ({ open, date, mode, onConfirm, onCancel, dark }) => {
+  const [currentDate, setCurrentDate] = useState(date);
+
+  useEffect(() => {
+    if (open) {
+      setCurrentDate(date);
+    }
+  }, [open, date]);
+
+  if (!open) return null;
+
+  return (
+    <Modal transparent animationType="slide" visible={open} onRequestClose={onCancel}>
+      <View style={styles.modalContainer}>
+        <View
+          style={[
+            styles.pickerContainer,
+            { backgroundColor: dark ? '#1c1c1e' : '#fff' },
+          ]}
+        >
+          <View style={styles.toolbar}>
+            <Button onPress={onCancel} compact uppercase={false} textColor="#4A90E2">
+              Отмена
+            </Button>
+            <Button
+              onPress={() => onConfirm(currentDate)}
+              compact
+              uppercase={false}
+              textColor="#4A90E2"
+            >
+              Готово
+            </Button>
+          </View>
+          <DateTimePicker
+            value={currentDate}
+            mode={mode}
+            display="spinner"
+            onChange={(event, selectedDate) => {
+              if (selectedDate) {
+                setCurrentDate(selectedDate);
+              }
+            }}
+            themeVariant={dark ? 'dark' : 'light'}
+            textColor={dark ? '#fff' : undefined}
+          />
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  modalContainer: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  pickerContainer: {
+    borderTopLeftRadius: 12,
+    borderTopRightRadius: 12,
+    paddingBottom: 16,
+  },
+  toolbar: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingTop: 8,
+  },
+});
 
 export default IOSDatePicker;


### PR DESCRIPTION
## Summary
- use @react-native-community/datetimepicker inside a modal
- add Cancel/Done actions for native iOS confirmation

## Testing
- `npm test` *(fails: Cannot find module './ScriptTransformer')*


------
https://chatgpt.com/codex/tasks/task_e_688dea751690832381cf6a1fb9af33e6