### PR TITLE
Refine task list visuals and status indicators

### DIFF
--- a/TaskManager/src/components/TaskItem.js
+++ b/TaskManager/src/components/TaskItem.js
@@ -9,11 +9,11 @@ import formatDate from '../utils/formatDate';
 const statusColor = (status) => {
   switch (status) {
     case 'Завершена':
-      return '#4CAF50';
+      return '#81C784';
     case 'Отменена':
-      return '#9E9E9E';
+      return '#BDBDBD';
     default:
-      return '#4A90E2';
+      return '#64B5F6';
   }
 };
 
@@ -28,33 +28,47 @@ const categoryIcon = (category) => {
   }
 };
 
-const TaskItem = ({ task, onPress, onToggle, onLongPress }) => (
-  <Card style={styles.item} onPress={onPress} onLongPress={onLongPress} mode="elevated">
-    <Card.Content style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
-      <View style={{ flexDirection: 'row', alignItems: 'center', flex: 1 }}>
-        <Avatar.Icon size={28} icon={categoryIcon(task.category)} style={{ marginRight: 8 }} />
-        <View style={{ flex: 1 }}>
-          <View style={{ flexDirection: 'row', alignItems: 'center', flexWrap: 'wrap' }}>
-            <Text style={styles.title}>{task.title}</Text>
-            <Badge
-              style={{
-                backgroundColor: statusColor(task.status),
-                color: '#FFFFFF',
-                marginLeft: 4,
-              }}
-            >
-              {task.status}
-            </Badge>
+const TaskItem = ({ task, onPress, onToggle, onLongPress }) => {
+  const overdue = new Date(task.date) < new Date() && task.status === 'В процессе';
+  return (
+    <Card style={styles.item} onPress={onPress} onLongPress={onLongPress} mode="elevated">
+      <Card.Content style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+        <View style={{ flexDirection: 'row', alignItems: 'center', flex: 1 }}>
+          <Avatar.Icon size={24} icon={categoryIcon(task.category)} style={{ marginRight: 8 }} />
+          <View style={{ flex: 1 }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', flexWrap: 'wrap' }}>
+              <Text style={styles.title}>{task.title}</Text>
+              <Badge
+                style={{
+                  backgroundColor: statusColor(task.status),
+                  color: '#FFFFFF',
+                  marginLeft: 4,
+                }}
+              >
+                {task.status}
+              </Badge>
+              {overdue && (
+                <Badge
+                  style={{
+                    backgroundColor: '#E57373',
+                    color: '#FFFFFF',
+                    marginLeft: 4,
+                  }}
+                >
+                  Просрочено
+                </Badge>
+              )}
+            </View>
+            <Text style={styles.secondary}>{formatDate(task.date)}</Text>
           </View>
-          <Text style={styles.secondary}>{formatDate(task.date)}</Text>
         </View>
-      </View>
-      <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-        {task.notificationId && <IconButton icon="bell" size={18} />}
-        <IconButton icon={task.pinned ? 'pin' : 'pin-outline'} onPress={onToggle} size={18} />
-      </View>
-    </Card.Content>
-  </Card>
-);
+        <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+          {task.notificationId && <IconButton icon="bell" size={18} />}
+          <IconButton icon={task.pinned ? 'pin' : 'pin-outline'} onPress={onToggle} size={18} />
+        </View>
+      </Card.Content>
+    </Card>
+  );
+};
 
 export default TaskItem;

--- a/TaskManager/src/screens/TaskListScreen.js
+++ b/TaskManager/src/screens/TaskListScreen.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { View, SectionList, Animated, LayoutAnimation } from 'react-native';
-import { FAB, Appbar, Menu, Searchbar, Text, Button, Divider, Snackbar, List } from 'react-native-paper';
+import { FAB, Appbar, Menu, Searchbar, Text, Button, Divider, Snackbar } from 'react-native-paper';
 import { useIsFocused } from '@react-navigation/native';
 import { useTasks } from '../context/TaskContext';
 import { useThemePreferences } from '../context/ThemeContext';
@@ -231,7 +231,9 @@ export default function TaskListScreen({ navigation }) {
             />
           )}
           renderSectionHeader={({ section: { title } }) => (
-            <List.Subheader>{title}</List.Subheader>
+            <View style={styles.sectionHeader}>
+              <Text style={styles.sectionHeaderText}>{title}</Text>
+            </View>
           )}
           ItemSeparatorComponent={Divider}
           contentContainerStyle={{ flexGrow: 1 }}
@@ -243,6 +245,7 @@ export default function TaskListScreen({ navigation }) {
         style={[styles.fab, { backgroundColor: paperTheme.colors.primary }]}
         icon="plus"
         onPress={() => navigation.navigate('TaskForm')}
+        size="small"
       />
       <Snackbar
         visible={!!snackbar}

--- a/TaskManager/src/styles/styles.js
+++ b/TaskManager/src/styles/styles.js
@@ -1,26 +1,41 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Platform } from 'react-native';
 
 export default StyleSheet.create({
   item: {
     marginVertical: 4,
     borderRadius: 8,
     elevation: 1,
-    paddingVertical: 8,
-    height: 64,
+    paddingVertical: 4,
+    height: 56,
   },
   title: {
     fontSize: 16,
     fontWeight: '500',
+    fontFamily: Platform.select({ ios: 'System', android: 'Roboto' }),
   },
   secondary: {
-    fontSize: 12,
-    color: '#B0B0B0',
+    fontSize: 11,
+    color: '#9E9E9E',
+    fontFamily: Platform.select({ ios: 'System', android: 'Roboto' }),
   },
   fab: {
-  position: 'absolute',
-  margin: 16,
-  right: 16,
-  bottom: 16,
+    position: 'absolute',
+    margin: 16,
+    right: 16,
+    bottom: 16,
+    elevation: 4,
+  },
+
+  sectionHeader: {
+    backgroundColor: '#EEEEEE',
+    paddingVertical: 4,
+    paddingHorizontal: 16,
+  },
+  sectionHeaderText: {
+    fontSize: 13,
+    fontWeight: '500',
+    color: '#555555',
+    fontFamily: Platform.select({ ios: 'System', android: 'Roboto' }),
   },
 
   container: {


### PR DESCRIPTION
## Summary
- streamline task cards with lighter fonts and section headers
- add overdue status badge and pastel badge colors
- shrink FAB size and lift with shadow for smaller footprint

## Testing
- `npm test` *(fails: Cannot find module './ScriptTransformer')*


------
https://chatgpt.com/codex/tasks/task_e_688dec8deb80832391bf2419401f5490