### PR TITLE
Tidy task cards and simplify settings

### DIFF
--- a/TaskManager/src/components/TaskItem.js
+++ b/TaskManager/src/components/TaskItem.js
@@ -32,7 +32,9 @@ const TaskItem = ({ task, onPress, onToggle, onLongPress }) => {
   const overdue = new Date(task.date) < new Date() && task.status === 'В процессе';
   return (
     <Card style={styles.item} onPress={onPress} onLongPress={onLongPress} mode="elevated">
-      <Card.Content style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+      <Card.Content
+        style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingVertical: 0 }}
+      >
         <View style={{ flexDirection: 'row', alignItems: 'center', flex: 1 }}>
           <Avatar.Icon size={24} icon={categoryIcon(task.category)} style={{ marginRight: 8 }} />
           <View style={{ flex: 1 }}>

--- a/TaskManager/src/screens/AboutScreen.js
+++ b/TaskManager/src/screens/AboutScreen.js
@@ -8,9 +8,14 @@ export default function AboutScreen() {
   const version = Constants.expoConfig?.version || '1.0.0';
   return (
     <View style={{ flex: 1, padding: 16, backgroundColor: theme.colors.background }}>
-      <Text variant="titleLarge" style={{ marginBottom: 8 }}>О приложении</Text>
-      <Text>Версия: {version}</Text>
-      <Text style={{ marginTop: 8 }}>Task Manager - приложение для управления задачами.</Text>
+      <Text variant="titleLarge" style={{ marginBottom: 8, textAlign: 'center' }}>
+        О приложении
+      </Text>
+      <Text style={{ textAlign: 'center' }}>Версия: {version}</Text>
+      <Text style={{ marginTop: 8, textAlign: 'center' }}>
+        Task Manager — приложение для планирования и отслеживания задач.
+        Создавайте задания, получайте напоминания и контролируйте прогресс.
+      </Text>
     </View>
   );
 }

--- a/TaskManager/src/screens/SettingsScreen.js
+++ b/TaskManager/src/screens/SettingsScreen.js
@@ -8,7 +8,7 @@ import * as Linking from 'expo-linking';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export default function SettingsScreen() {
-  const { accentColor, setAccentColor, toggleTheme, theme } = useThemePreferences();
+  const { accentColor, setAccentColor } = useThemePreferences();
   const paper = useTheme();
   const colors = ['#6750A4', '#ff5722', '#009688'];
   const [notifStatus, setNotifStatus] = useState('unknown');
@@ -27,14 +27,6 @@ export default function SettingsScreen() {
     <View style={{ flex: 1, padding: 16, backgroundColor: paper.colors.background }}>
       <List.Section>
         <List.Subheader>Отображение</List.Subheader>
-        <List.Item
-          title={theme === 'light' ? 'Тёмная тема' : 'Светлая тема'}
-          onPress={() => {
-            toggleTheme();
-            setSnackbar('Тема изменена');
-          }}
-          left={() => <List.Icon icon="theme-light-dark" />}
-        />
         <RadioButton.Group onValueChange={setAccentColor} value={accentColor}>
           {colors.map((c) => (
             <RadioButton.Item key={c} label={c} value={c} color={c} />

--- a/TaskManager/src/styles/styles.js
+++ b/TaskManager/src/styles/styles.js
@@ -5,8 +5,8 @@ export default StyleSheet.create({
     marginVertical: 4,
     borderRadius: 8,
     elevation: 1,
-    paddingVertical: 4,
-    height: 56,
+    paddingVertical: 8,
+    minHeight: 56,
   },
   title: {
     fontSize: 16,


### PR DESCRIPTION
## Summary
- Center text within task cards and allow them to grow
- Describe app purpose on the About screen
- Remove redundant dark theme toggle from settings

## Testing
- `npm test` *(fails: Cannot find module './ScriptTransformer')*

------
https://chatgpt.com/codex/tasks/task_e_688e1f04b054832399fa0c54ec10e731