### PR TITLE
feat: enable dark theme defaults

### DIFF
--- a/TaskManager/App.js
+++ b/TaskManager/App.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import * as Notifications from 'expo-notifications';
 import { Provider as PaperProvider } from 'react-native-paper';
+import { StatusBar } from 'expo-status-bar';
 import AppNavigator from './src/navigation/AppNavigator';
 import { registerForPushNotificationsAsync } from './src/services/notificationService';
 import { TaskProvider } from './src/context/TaskContext';
@@ -27,6 +28,7 @@ function MainApp() {
 
   return (
     <PaperProvider theme={paperTheme}>
+      <StatusBar style={paperTheme.dark ? 'light' : 'dark'} />
       <TaskProvider>
         {user ? <AppNavigator /> : <SignInScreen onSignIn={setUser} />}
       </TaskProvider>

--- a/TaskManager/app.json
+++ b/TaskManager/app.json
@@ -5,11 +5,11 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./tasklist.png",
-    "userInterfaceStyle": "light",
+    "userInterfaceStyle": "dark",
     "splash": {
       "image": "./task-manager/assets/images/splash-icon.png",
       "resizeMode": "contain",
-      "backgroundColor": "#ffffff"
+      "backgroundColor": "#000000"
     },
     "updates": {
       "fallbackToCacheTimeout": 0
@@ -19,14 +19,19 @@
     ],
     "ios": {
       "bundleIdentifier": "com.nepovtor.taskmanager",
-      "supportsTablet": true
+      "supportsTablet": true,
+      "userInterfaceStyle": "dark"
     },
     "android": {
       "package": "com.nepovtor.taskmanager",
       "adaptiveIcon": {
         "foregroundImage": "./tasklist.png",
-        "backgroundColor": "#ffffff"
+        "backgroundColor": "#000000"
       }
+    },
+    "androidStatusBar": {
+      "backgroundColor": "#000000",
+      "barStyle": "light-content"
     },
     "web": {
       "favicon": "./tasklist.png"

--- a/TaskManager/ios/taskmanager/Info.plist
+++ b/TaskManager/ios/taskmanager/Info.plist
@@ -53,7 +53,7 @@
     <key>UIRequiresFullScreen</key>
     <false/>
     <key>UIStatusBarStyle</key>
-    <string>UIStatusBarStyleDefault</string>
+    <string>UIStatusBarStyleLightContent</string>
     <key>UISupportedInterfaceOrientations</key>
     <array>
       <string>UIInterfaceOrientationPortrait</string>
@@ -62,7 +62,7 @@
       <string>UIInterfaceOrientationLandscapeRight</string>
     </array>
     <key>UIUserInterfaceStyle</key>
-    <string>Light</string>
+    <string>Dark</string>
     <key>UIViewControllerBasedStatusBarAppearance</key>
     <false/>
   </dict>

--- a/TaskManager/src/context/ThemeContext.js
+++ b/TaskManager/src/context/ThemeContext.js
@@ -55,7 +55,7 @@ const ThemeContext = createContext({
 
 export const ThemeProvider = ({ children }) => {
   const systemScheme = useColorScheme();
-  const [theme, setTheme] = useState(systemScheme || 'light');
+  const [theme, setTheme] = useState(systemScheme || 'dark');
   const [accentColor, setAccentColorState] = useState(DEFAULT_ACCENT);
 
   useEffect(() => {

--- a/TaskManager/task-manager/app.json
+++ b/TaskManager/task-manager/app.json
@@ -6,15 +6,16 @@
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "taskmanager",
-    "userInterfaceStyle": "automatic",
+    "userInterfaceStyle": "dark",
     "newArchEnabled": true,
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "userInterfaceStyle": "dark"
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/adaptive-icon.png",
-        "backgroundColor": "#ffffff"
+        "backgroundColor": "#000000"
       },
       "edgeToEdgeEnabled": true
     },
@@ -31,10 +32,14 @@
           "image": "./assets/images/splash-icon.png",
           "imageWidth": 200,
           "resizeMode": "contain",
-          "backgroundColor": "#ffffff"
+          "backgroundColor": "#000000"
         }
       ]
     ],
+    "androidStatusBar": {
+      "backgroundColor": "#000000",
+      "barStyle": "light-content"
+    },
     "experiments": {
       "typedRoutes": true
     }

--- a/TaskManager/task-manager/app/_layout.tsx
+++ b/TaskManager/task-manager/app/_layout.tsx
@@ -6,7 +6,7 @@ import 'react-native-reanimated';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
 export default function RootLayout() {
-  const colorScheme = useColorScheme();
+  const colorScheme = useColorScheme() || 'dark';
 
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
@@ -14,7 +14,7 @@ export default function RootLayout() {
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="+not-found" />
       </Stack>
-      <StatusBar style="auto" />
+      <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
## Summary
- default to a dark interface with black splash screens and status bars
- set dark theme as initial preference and adjust status bar text accordingly
- configure iOS/Android metadata for dark appearance

## Testing
- `npm test` *(fails: Cannot find module './ScriptTransformer')*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e59d4e2a483238aa892f018a47bc1