### PR TITLE
Add unit tests for auth service and date formatting

### DIFF
--- a/TaskManager/__tests__/authService.test.js
+++ b/TaskManager/__tests__/authService.test.js
@@ -1,0 +1,9 @@
+const { signInWithGoogle } = require('../src/services/authService');
+
+describe('authService', () => {
+  test('signInWithGoogle returns default user object', async () => {
+    const user = await signInWithGoogle();
+    expect(user).toHaveProperty('name', 'User');
+    expect(typeof user.id).toBe('string');
+  });
+});

--- a/TaskManager/__tests__/formatDate.test.js
+++ b/TaskManager/__tests__/formatDate.test.js
@@ -1,0 +1,9 @@
+process.env.TZ = 'UTC';
+const formatDate = require('../src/utils/formatDate').default;
+
+describe('formatDate', () => {
+  test('formats ISO string into human readable Russian date', () => {
+    const result = formatDate('2023-05-15T14:30:00.000Z');
+    expect(result).toBe('15 мая 2023, 14:30');
+  });
+});


### PR DESCRIPTION
## Summary
- add test for `signInWithGoogle`
- cover date formatting helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e5c88964083239a10360cb37e5e6f