### PR TITLE
fix: ensure tests run

### DIFF
--- a/TaskManager/jest.config.js
+++ b/TaskManager/jest.config.js
@@ -2,5 +2,6 @@ module.exports = {
   transform: {
     '^.+\\.jsx?$': 'babel-jest'
   },
-  testEnvironment: 'node'
+  testEnvironment: 'node',
+  modulePathIgnorePatterns: ['<rootDir>/task-manager']
 };

--- a/TaskManager/package-lock.json
+++ b/TaskManager/package-lock.json
@@ -43,6 +43,7 @@
       "devDependencies": {
         "@babel/core": "^7.24.0",
         "@babel/preset-env": "^7.28.0",
+        "@jest/transform": "~29.7.0",
         "babel-jest": "~29.7.0",
         "jest": "~29.7.0"
       }

--- a/TaskManager/package.json
+++ b/TaskManager/package.json
@@ -46,7 +46,8 @@
     "@babel/core": "^7.24.0",
     "@babel/preset-env": "^7.28.0",
     "babel-jest": "~29.7.0",
-    "jest": "~29.7.0"
+    "jest": "~29.7.0",
+    "@jest/transform": "~29.7.0"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- ignore nested `task-manager` package in Jest to avoid haste collisions
- add `@jest/transform` dev dependency so ScriptTransformer is available

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e7eda0e308323858c7bbe5b0d6732