### PR TITLE
Add swipe animation and simplify date display

### DIFF
--- a/TaskManager/__tests__/formatDate.test.js
+++ b/TaskManager/__tests__/formatDate.test.js
@@ -4,6 +4,21 @@ const formatDate = require('../src/utils/formatDate').default;
 describe('formatDate', () => {
   test('formats ISO string into human readable Russian date', () => {
     const result = formatDate('2023-05-15T14:30:00.000Z');
-    expect(result).toBe('15 мая 2023, 14:30');
+    expect(result).toBe('15 мая 2023');
+  });
+
+  test('returns Сегодня for today', () => {
+    const today = new Date().toISOString();
+    expect(formatDate(today)).toBe('Сегодня');
+  });
+
+  test('returns Завтра for tomorrow', () => {
+    const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    expect(formatDate(tomorrow)).toBe('Завтра');
+  });
+
+  test('returns Вчера for yesterday', () => {
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    expect(formatDate(yesterday)).toBe('Вчера');
   });
 });

--- a/TaskManager/src/utils/formatDate.js
+++ b/TaskManager/src/utils/formatDate.js
@@ -3,5 +3,9 @@ import 'dayjs/locale/ru';
 
 export default function formatDate(dateString) {
   const d = dayjs(dateString).locale('ru');
-  return d.format('D MMMM YYYY, HH:mm');
+  const diff = d.startOf('day').diff(dayjs().startOf('day'), 'day');
+  if (diff === 0) return 'Сегодня';
+  if (diff === 1) return 'Завтра';
+  if (diff === -1) return 'Вчера';
+  return d.format('D MMMM YYYY');
 }


### PR DESCRIPTION
## Summary
- animate day switching with horizontal slide
- format dates without time and show relative labels

## Testing
- `npm test` *(fails: Cannot find module './ScriptTransformer')*

------
https://chatgpt.com/codex/tasks/task_e_688e853084288323be198c3822c6a807